### PR TITLE
Use python3 by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,5 @@ JS_FILES=media/js/src media/js/tests
 all: jenkins
 
 include *.mk
+
+SYS_PYTHON=python3


### PR DESCRIPTION
This app isn't deployed yet, but I expect we'll set up some new
python 3 servers before January.

If not, well, going back to python 2 remains an option.