### PR TITLE
Include django-cacheds3storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -82,6 +82,7 @@ gunicorn==19.7.1
 django-infranil==1.1.0
 django-flatblocks==0.9.4
 django-storages-redux==1.3.3
+django-cacheds3storage==0.1.2
 
 djangorestframework==3.7.1
 Willow==1.0


### PR DESCRIPTION
This is required by staging.py in ccnmtlsettings.