### PR TITLE
Add cryptography with --no-binary

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -29,7 +29,7 @@ $(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
 	rm -rf $(VE)
 	$(SYS_PYTHON) $(VIRTUALENV) --extra-search-dir=$(SUPPORT_DIR) --never-download $(VE)
 	$(PIP) install wheel==$(WHEEL_VERSION)
-	$(PIP) install --use-wheel --no-deps --requirement $(REQUIREMENTS)
+	$(PIP) install --use-wheel --no-deps --requirement $(REQUIREMENTS) --no-binary cryptography
 	$(SYS_PYTHON) $(VIRTUALENV) --relocatable $(VE)
 	touch $@
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ rdflib==4.2.2
 selenium==3.6.0
 coverage==4.4.1
 pyasn1==0.3.7
+cryptography==2.1.1  # pyOpenSSL
 pyOpenSSL==17.3.0
 ndg-httpsclient==0.4.3
 urllib3==1.22  # requests


### PR DESCRIPTION
This fixes an error I encountered when starting gunicorn:

    File
    "/var/www/econplayground/releases/green/econplayground/ve/lib/python3.5/site-packages/OpenSSL/SSL.py",
    line 115, in <module>
        if _lib.Cryptography_HAS_SSL_ST:

    AttributeError: module 'lib' has no attribute 'Cryptography_HAS_SSL_ST'