### PR TITLE
Remove CSRF middleware

### DIFF
--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -23,8 +23,17 @@ REST_FRAMEWORK = {
     )
 }
 
-MIDDLEWARE_CLASSES += [  # noqa
-    'django.middleware.csrf.CsrfViewMiddleware',
+MIDDLEWARE = [
+    'django_statsd.middleware.GraphiteRequestTimingMiddleware',
+    'django_statsd.middleware.GraphiteMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'waffle.middleware.WaffleMiddleware',
+    'impersonate.middleware.ImpersonateMiddleware',
 ]
 
 INSTALLED_APPS += [  # noqa


### PR DESCRIPTION
Loading the LTI landing page gives me a CSRF error when it's enabled,
even when I have CSRF_TRUSTED_ORIGINS set, so I'm just removing it for
now.