### PR TITLE
add back in CSRF middleware

### DIFF
--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -27,6 +27,7 @@ MIDDLEWARE = [
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
The front-end needs this to function, and I really should use it anyways. I'll figure out a way to get LTI to work with this, even if it involves making those views exempt from CSRF.