### PR TITLE
Enable assignment embed

### DIFF
--- a/econplayground/main/views.py
+++ b/econplayground/main/views.py
@@ -6,6 +6,7 @@ from django.views.generic.edit import CreateView
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from lti_provider.mixins import LTIAuthMixin
+from braces.views import CsrfExemptMixin
 from econplayground.main.models import Graph
 
 
@@ -44,9 +45,13 @@ class GraphDetailView(LoginRequiredMixin, DetailView):
         return HttpResponseRedirect(url)
 
 
-class GraphEmbedView(EnsureCsrfCookieMixin, LTIAuthMixin, DetailView):
+class GraphEmbedView(CsrfExemptMixin, LTIAuthMixin, DetailView):
     model = Graph
     template_name = 'main/graph_embed.html'
+
+    def post(self, request, pk=None):
+        url = reverse('graph_embed', kwargs={'pk': pk})
+        return HttpResponseRedirect(url)
 
 
 class GraphDeleteView(UserPassesTestMixin, DeleteView):

--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -70,6 +70,6 @@ LTI_TOOL_CONFIGURATION = {
     'new_tab': True,
     'course_aware': False,
     'frame_width': 600,
-    'frame_height': 480,
+    'frame_height': 620,
     'landing_url': '/',
 }

--- a/econplayground/templates/main/graph_detail.html
+++ b/econplayground/templates/main/graph_detail.html
@@ -33,12 +33,6 @@
         <hr />
 
         <div>
-            <!--
-            TODO: display this outside of canvas
-            <h3>Embed Graph</h3>
-            <textarea class="form-control" placeholder rows="1" autocomplete="off" style="resize: none;"><iframe width="560" height="600" src="{{ request.scheme }}://{{ request.get_host }}{% url 'graph_embed' object.pk %}"></iframe></textarea>
-            -->
-
             <form id="asset-embed-form" action="." method="post">{% csrf_token %}
                 <input type="hidden" name="return_url"
                        value="https://courseworks2.columbia.edu/courses/54465/external_content/success/external_tool_dialog">

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,3 +101,5 @@ oauth2==1.9.0.post1
 pylti==0.5.1
 nameparser==0.5.3
 django-lti-provider==0.2.2
+
+django-braces==1.11.0


### PR DESCRIPTION
I'll also need to make more changes to this response, like passing through LTI and/or Oauth params (per LTIRoutingView) so the Submit button works correctly for grade passback. This change just allows the embed view to be read from the assignment interface.