### PR TITLE
Add missing typing module for django-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,6 +77,7 @@ django-debug-toolbar==1.9.1
 django-waffle==0.12.0
 django-jenkins==0.110.0
 django-smoketest==1.1.0
+typing==3.6.2  # For django-extensions
 django-extensions==1.9.8
 django-stagingcontext==0.1.0
 django-ga-context==0.1.0


### PR DESCRIPTION
required on python <= 3.4