### PR TITLE
Add django-smtp-ssl dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -102,4 +102,5 @@ nameparser==0.5.4
 django-lti-provider==0.3.0
 
 django-braces==1.12.0
+django-smtp-ssl==1.0
 django-contact-us==0.4.0


### PR DESCRIPTION
This library acts as a shim for the AWS SES email. This backend is specified in local_settings.py along with other settings to enable the service.