### PR TITLE
Add user_is_instructor - PMT #113636

### DIFF
--- a/econplayground/main/templatetags/econ_auth.py
+++ b/econplayground/main/templatetags/econ_auth.py
@@ -1,0 +1,10 @@
+from django import template
+from econplayground.main.utils import user_is_instructor
+
+
+register = template.Library()
+
+
+@register.simple_tag(name='user_is_instructor')
+def tag(user):
+    return user_is_instructor(user)

--- a/econplayground/main/utils.py
+++ b/econplayground/main/utils.py
@@ -1,0 +1,5 @@
+INSTRUCTOR_LIST = ['tg2451']
+
+
+def user_is_instructor(user):
+    return user.username in INSTRUCTOR_LIST or user.is_staff

--- a/econplayground/main/views.py
+++ b/econplayground/main/views.py
@@ -17,6 +17,7 @@ from lti_provider.mixins import LTIAuthMixin
 from lti_provider.views import LTILandingPage
 
 from econplayground.main.models import Graph, Submission
+from econplayground.main.utils import user_is_instructor
 
 
 class EnsureCsrfCookieMixin(object):
@@ -36,7 +37,7 @@ class GraphCreateView(EnsureCsrfCookieMixin, UserPassesTestMixin, CreateView):
     fields = ['title', 'description', 'graph_type']
 
     def test_func(self):
-        return self.request.user.is_staff
+        return user_is_instructor(self.request.user)
 
 
 class GraphDetailView(LoginRequiredMixin, DetailView):
@@ -82,14 +83,14 @@ class GraphDeleteView(UserPassesTestMixin, DeleteView):
     success_url = '/'
 
     def test_func(self):
-        return self.request.user.is_staff
+        return user_is_instructor(self.request.user)
 
 
 class GraphListView(LoginRequiredMixin, ListView):
     model = Graph
 
     def get_queryset(self):
-        if self.request.user.is_staff:
+        if user_is_instructor(self.request.user):
             return Graph.objects.all()
 
         return Graph.objects.filter(needs_submit=False, is_published=True)

--- a/econplayground/templates/base.html
+++ b/econplayground/templates/base.html
@@ -1,4 +1,4 @@
-{% load compress static %}
+{% load compress static econ_auth %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -55,6 +55,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
 </head>
 
+{% user_is_instructor request.user as i_am_instructor %}
 <body class="{% block bodyclass %}{% endblock %}" id="{% block bodyid %}{% endblock %}">
     {% block content-container %}
     <main role="main" class="container">
@@ -78,7 +79,7 @@
                             Home
                         </a>
                     </li>
-                    {% if request.user.is_staff %}
+                    {% if i_am_instructor %}
                         <li class="nav-item">
                             {% url 'graph_create' as the_url %}
                             <a class="nav-link {% if request.path == the_url %}active{% endif %}"
@@ -144,8 +145,14 @@
     <script>
         var EconPlayground = {
             {% if not request.user.is_anonymous %}
-                'user': {{ request.user.id }},
-                'is_staff': {{ request.user.is_staff|yesno:"true,false,undefined"}}
+            'user': {{ request.user.id }},
+            {% if i_am_instructor %}
+                'is_instructor': true,
+                'is_staff': true
+            {% else %}
+                'is_instructor': false,
+                'is_staff': false
+            {% endif %}
             {% endif %}
         };
     </script>

--- a/econplayground/templates/main/graph_embed.html
+++ b/econplayground/templates/main/graph_embed.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static econ_auth %}
 <!DOCTYPE html>
 <html>
     <head>
@@ -18,7 +18,8 @@
                     window.EconPlayground = {};
                 }
 
-                window.EconPlayground['isStaff'] = '{{request.user.is_staff}}';
+                window.EconPlayground['isStaff'] = '{% user_is_instructor request.user %}';
+                window.EconPlayground['isInstructor] = '{% user_is_instructor request.user %}';
                 window.EconPlayground['LTIPostGrade'] = '{% url 'lti-post-grade' %}';
                 window.EconPlayground['EmbedSuccess'] = '{% url 'graph_embed' object.pk %}?submitted=1';
                 window.EconPlayground['EmbedLaunchUrl'] = '{% url 'graph_embed' object.pk %}?submitted=1';


### PR DESCRIPTION
This extends our auth model beyond just the automatically provided
is_staff concept to be customizable. Users in this system are either an
"instructor", or not. At the moment, an instructor is either Thomas, or
any of our staff.

I've added new is_instructor JS variables, but leaving the old is_staff
variable for now until I change the JS code as well.