### PR TITLE
Remove enum34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ statsd==3.2.2
 pep8==1.7.1
 pyflakes==1.6.0
 mccabe==0.6.1
-enum34==1.1.6
 configparser==3.5.0
 pycodestyle==2.3.1
 flake8==3.5.0


### PR DESCRIPTION
This fixes the `make flake8` step in my local environment, which is now
python 3.6. This package is only required for older versions of python
that we don't expect to run econplayground on.