### PR TITLE
Remove django-jenkins and coverage

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -34,7 +34,7 @@ $(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
 	touch $@
 
 test: $(PY_SENTINAL)
-	$(VE)/bin/python -Wd $(MANAGE) jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc
+	$(VE)/bin/python -Wd $(MANAGE) test
 
 parallel-tests: $(PY_SENTINAL)
 	$(MANAGE) test --parallel

--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -47,7 +47,6 @@ INSTALLED_APPS = [  # noqa
     'django.contrib.admin',
     'django_statsd',
     'smoketest',
-    'django_jenkins',
     'gunicorn',
     'compressor',
     'djangowind',

--- a/package-lock.json
+++ b/package-lock.json
@@ -500,9 +500,9 @@
       }
     },
     "eslint": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
-      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
+      "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -514,13 +514,13 @@
         "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.2",
+        "espree": "3.5.3",
         "esquery": "1.0.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.1.0",
+        "globals": "11.3.0",
         "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "3.2.2",
@@ -545,9 +545,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+          "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
           "dev": true
         },
         "debug": {
@@ -569,19 +569,19 @@
           }
         },
         "espree": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-          "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+          "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
           "dev": true,
           "requires": {
-            "acorn": "5.3.0",
+            "acorn": "5.4.1",
             "acorn-jsx": "3.0.1"
           }
         },
         "globals": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-          "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
           "dev": true
         }
       }
@@ -835,7 +835,7 @@
       "dev": true,
       "requires": {
         "babel-eslint": "7.2.3",
-        "eslint": "4.15.0"
+        "eslint": "4.17.0"
       }
     },
     "eslint-plugin-security": {
@@ -1290,6 +1290,12 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1368,9 +1374,9 @@
       }
     },
     "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
+      "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1422,6 +1428,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.2.tgz",
+      "integrity": "sha512-rvxf+PSZeCKtP0DgmwMmNf1G3I6X1r4WHiP2H88PlIkOkt7mGqufdokjS8caoHBgZzVx0ee/5ytGcGHbZaUw8w==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        }
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1763,61 +1790,28 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.3.tgz",
-      "integrity": "sha512-c7u0ZuvBRX1eXuB4jN3BRCAOGiUTlM8SE3TxbJHrNiHUKL7wonujMOB6Fi1gQc00U91IscFORQHDga/eccqpbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.2.tgz",
+      "integrity": "sha512-BEa593xl+IkIc94nKo0O0LauQC/gQy8Gyv4DkzPwF/9DweC5phr1y+42zibCpn9abfkdHxt9r8AhD0R6u9DE/Q==",
       "dev": true,
       "requires": {
         "diff": "3.3.1",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
         "lolex": "2.3.1",
-        "nise": "1.2.0",
-        "supports-color": "4.5.0",
-        "type-detect": "4.0.5"
+        "nise": "1.2.2",
+        "supports-color": "5.1.0",
+        "type-detect": "4.0.8"
       },
       "dependencies": {
-        "just-extend": {
-          "version": "1.1.27",
-          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-          "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
-          "dev": true
-        },
-        "nise": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-          "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
-          "dev": true,
-          "requires": {
-            "formatio": "1.2.0",
-            "just-extend": "1.1.27",
-            "lolex": "1.6.0",
-            "path-to-regexp": "1.7.0",
-            "text-encoding": "0.6.4"
-          },
-          "dependencies": {
-            "lolex": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-              "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-              "dev": true
-            }
-          }
-        },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
-        },
-        "type-detect": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-          "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
-          "dev": true
         }
       }
     },
@@ -1982,6 +1976,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ scandir==1.6  # ipython
 ipython==6.2.1
 ipdb==0.10.3
 rdflib==4.2.2
-coverage==4.5
 pyasn1==0.4.2
 cryptography==2.1.4  # pyOpenSSL
 pyOpenSSL==17.5.0
@@ -73,7 +72,6 @@ raven==6.5.0
 django-bootstrap4==0.0.5
 django-debug-toolbar==1.9.1
 django-waffle==0.13.0
-django-jenkins==0.110.0
 django-smoketest==1.1.0
 typing==3.6.4  # For django-extensions
 django-extensions==1.9.9


### PR DESCRIPTION
I'm not using automated coverage checks, and django-jenkins is not
really maintained, and not even necessary for our purposes. There's no
reason not to just use `./manage.py test` here. I've kept the `jenkins`
make target name to run the `check flake8 test eslint` targets.