### PR TITLE
Remove pyOpenSSL dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,10 +37,8 @@ ipython==6.4.0
 ipdb==0.11
 rdflib==4.2.2
 coverage==4.5.1
-pyasn1==0.4.3
-cryptography==2.2.2  # pyOpenSSL
-pyOpenSSL==18.0.0
-ndg-httpsclient==0.5.0
+asn1crypto==0.24.0  # cryptography
+cryptography==2.2.2
 urllib3==1.22  # requests
 chardet==3.0.4  # requests
 idna==2.6  # requests


### PR DESCRIPTION
Because econplayground is running on a reasonably new version of python,
pyOpenSSL isn't required. Our python 2.7.6 apps currently require this (see
settings_shared.py), and pyOpenSSL recommends actually using the
cryptography package instead - see https://github.com/pyca/pyopenssl

In fact, I'm not sure that the cryptography package is required either -
removing this package could speed up the build process. I'll investigate
further after this is merged.