### PR TITLE
Fix a few pip warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Pillow==5.1.0
 versiontools==1.9.1
 statsd==3.2.2
 pep8==1.7.1
-pyflakes==2.0.0
+pyflakes==1.6.0  # pyup: <1.7.0
 mccabe==0.6.1
 configparser==3.5.0
 pycodestyle==2.3.1 # pyup: <2.4.0
@@ -28,7 +28,7 @@ pickleshare==0.7.4  # ipython
 simplegeneric==0.8.1  # ipython
 path.py==11.0.1  # ipython
 wcwidth==0.1.7  # ipython
-prompt_toolkit==2.0.3  # ipython
+prompt_toolkit==1.0.15  # pyup: <2.0.0
 pygments==2.2.0  # ipython
 scandir==1.7  # ipython
 backcall==0.1.0  # ipython


### PR DESCRIPTION
> flake8 3.5.0 has requirement pyflakes<1.7.0,>=1.5.0, but you'll have
> pyflakes 2.0.0 which is incompatible.

> ipython 6.4.0 has requirement prompt-toolkit<2.0.0,>=1.0.15, but you'll
> have prompt-toolkit 2.0.3 which is incompatible.