### PR TITLE
Use custom INSTRUCTOR_LIST - ECON-335

### DIFF
--- a/econplayground/main/utils.py
+++ b/econplayground/main/utils.py
@@ -1,5 +1,13 @@
+from django.conf import settings
+
 INSTRUCTOR_LIST = ['tg2451']
 
 
 def user_is_instructor(user):
-    return user.username in INSTRUCTOR_LIST or user.is_staff
+    try:
+        # Use INSTRUCTOR_LIST from local_settings if it exists.
+        instructor_list = settings.INSTRUCTOR_LIST
+    except AttributeError:
+        instructor_list = INSTRUCTOR_LIST
+
+    return (user.username in instructor_list) or user.is_staff


### PR DESCRIPTION
This lets us define new instructors in local_settings.py (i.e., users
that can create graphs). As long as these new users don't have staff
or superuser status, they won't be able to use the admin section of the
site.