### PR TITLE
Remove ipython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,21 +19,6 @@ cssselect==1.0.3
 lxml==4.3.4
 fuzzywuzzy==0.17.0
 sure==1.4.11
-traitlets==4.3.2  # ipython
-ipython_genutils==0.2.0  # ipython
-decorator==4.4.0  # ipython
-ptyprocess==0.6.0  # ipython
-pexpect==4.7.0  # ipython
-pickleshare==0.7.5  # ipython
-simplegeneric==0.8.1  # ipython
-path.py==12.0.1  # ipython
-wcwidth==0.1.7  # ipython
-prompt_toolkit==1.0.16  # pyup: <2.0.0
-pygments==2.4.2  # ipython
-scandir==1.10.0  # ipython
-backcall==0.1.0  # ipython
-ipython==7.6.1
-ipdb==0.12
 coverage==4.5.3
 asn1crypto==0.24.0  # cryptography
 cryptography==2.7


### PR DESCRIPTION
These dependencies keep breaking, and are too hard to keep up with
without getting handled automatically, like with pipenv.