### PR TITLE
Allow instructors to create new courses

### DIFF
--- a/econplayground/main/tests/test_views.py
+++ b/econplayground/main/tests/test_views.py
@@ -85,6 +85,9 @@ class EmbedViewPublicAnonTest(TestCase):
 class CohortListInstructorViewTest(LoggedInTestInstructorMixin, TestCase):
     def test_get(self):
         cohort = CohortFactory()
+        my_cohort = CohortFactory()
+        my_cohort.instructors.add(self.u)
+
         r = self.client.get(reverse('cohort_list'))
 
         self.assertEqual(r.status_code, 200)
@@ -93,11 +96,10 @@ class CohortListInstructorViewTest(LoggedInTestInstructorMixin, TestCase):
         # Hide cohorts this instructor isn't a part of.
         self.assertNotContains(r, cohort.title)
 
-        # TODO: fix this assertion
-        # self.assertContains(r, 'New Course')
+        self.assertContains(r, 'Create a new course.')
 
-        # self.assertContains(r, cohort.title)
-        # self.assertContains(r, cohort.description)
+        self.assertContains(r, my_cohort.title)
+        self.assertContains(r, my_cohort.description)
 
 
 class CohortListStudentViewTest(LoggedInTestStudentMixin, TestCase):

--- a/econplayground/templates/main/cohort_list.html
+++ b/econplayground/templates/main/cohort_list.html
@@ -9,7 +9,8 @@
             <h1>My Courses</h1>
 
             <div class="d-flex align-content-stretch flex-wrap">
-                {% if perms.main.abc %}
+                {% user_is_instructor request.user as i_am_instructor %}
+                {% if i_am_instructor %}
                     <div class="card darkslate card-shadow">
                         <a href="{% url 'cohort_create' %}">
                             <div class="card-body">


### PR DESCRIPTION
This was accidentally hidden in the UI, causing a test failure.