### PR TITLE
:arrow_up: django-markwhat 1.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ django-stagingcontext==0.1.0
 django-ga-context==0.1.0
 django-global-context==0.1.1
 django-registration-redux==2.6
-django-markwhat==1.6.1
+django-markwhat==1.6.2
 gunicorn==19.9.0
 django-infranil==1.1.0
 django-flatblocks==0.9.4


### PR DESCRIPTION
This fixes the About and Credits page, which are currently broken.