### PR TITLE
Don't crash when topic param is an invalid string instead of id

### DIFF
--- a/econplayground/main/tests/test_views.py
+++ b/econplayground/main/tests/test_views.py
@@ -546,6 +546,12 @@ class CohortDetailInstructorViewTest(LoggedInTestInstructorMixin, TestCase):
         self.assertEqual(r.context['topic_list'][3].graph_count(), 0)
         self.assertEqual(r.context['topic_list'][4].graph_count(), 1)
 
+    def test_get_bad_topic(self):
+        r = self.client.get(
+            reverse('cohort_detail', kwargs={'pk': self.cohort.pk}) +
+            '?topic=abc')
+        self.assertEqual(r.status_code, 200)
+
 
 class CohortDetailStudentViewTest(LoggedInTestStudentMixin, TestCase):
     def setUp(self):

--- a/econplayground/main/views.py
+++ b/econplayground/main/views.py
@@ -254,7 +254,13 @@ class CohortDetailView(LoginRequiredMixin, DetailView):
             graphs = graphs.filter(featured=True)
             return graphs.order_by('order')
         elif 'topic' in params:
-            tid = params.get('topic', '')
+            tid = None
+
+            try:
+                tid = int(params.get('topic', ''))
+            except ValueError:
+                return graphs.order_by('title')
+
             if tid:
                 graphs = graphs.filter(topic=tid)
 
@@ -293,7 +299,10 @@ class CohortDetailView(LoginRequiredMixin, DetailView):
             context['featured'] = True
         elif 'topic' in params:
             tid = params.get('topic', '')
-            context['active_topic'] = int(tid)
+            try:
+                context['active_topic'] = int(tid)
+            except ValueError:
+                pass
 
         return context
 


### PR DESCRIPTION
Fixes the sentry errors that have appeared like:

  ValueError: invalid literal for int() with base 10: 'Fiscal Policy'

These routes should really be refactored to use Django's url routing
(#792). I'll make a different PR for that.