### PR TITLE
Add course password gate - ECON-361

### DIFF
--- a/econplayground/main/mixins.py
+++ b/econplayground/main/mixins.py
@@ -1,32 +1,72 @@
-from django.http import HttpResponseForbidden
+import hashlib
+from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 
 from econplayground.main.models import Cohort, Graph
 from econplayground.main.utils import user_is_instructor
 
 
-class CohortMixin(object):
-    """Find the cohort and attach it to self.cohort.
-
-    First, look for the cohort id in the URL, i.e. at
-    /course/<id>/etc..
-
-    Otherwise, look for a graph id, and find the cohort based on
-    that.
-    """
-    def dispatch(self, *args, **kwargs):
+def attach_cohort(view, **kwargs):
+    if not hasattr(view, 'cohort'):
         cohort_pk = kwargs.get('cohort_pk', None)
         graph_pk = kwargs.get('pk', None)
-
         if cohort_pk:
-            self.cohort = get_object_or_404(Cohort, pk=cohort_pk)
+            view.cohort = get_object_or_404(Cohort, pk=cohort_pk)
+        elif hasattr(view, 'get_object'):
+            view.cohort = view.get_object()
         elif graph_pk:
-            # No cohort id in the URL! Get the cohort from the graph.
             graph = get_object_or_404(Graph, pk=graph_pk)
-            self.cohort = graph.topic.cohort
+            view.cohort = graph.topic.cohort
 
-        return super(CohortMixin, self).dispatch(
+
+class CohortGraphMixin(object):
+    """Find the cohort and attach it to self.cohort.
+
+    To be used on Graph model views.
+    """
+    def dispatch(self, *args, **kwargs):
+        if not hasattr(self, 'cohort'):
+            graph_pk = kwargs.get('pk', None)
+            if graph_pk:
+                graph = get_object_or_404(Graph, pk=graph_pk)
+                self.cohort = graph.topic.cohort
+
+        return super(CohortGraphMixin, self).dispatch(
             self.request, *args, **kwargs)
+
+
+class CohortPasswordMixin(object):
+    """Require the cohort's password.
+
+    Redirect to the cohort password page if this cohort's password
+    isn't saved in the current session.
+
+    If there's a current user who is an instructor for this cohort, don't
+    redirect to the password page.
+    """
+    @staticmethod
+    def password_match(plaintext_pass, hashed_pass2):
+        hashed_pass1 = hashlib.sha224(
+               plaintext_pass.strip().encode('utf-8')).hexdigest()
+        return hashed_pass1 == hashed_pass2
+
+    def dispatch(self, *args, **kwargs):
+        attach_cohort(self, **kwargs)
+
+        is_instructor = self.request.user in self.cohort.instructors.all()
+        pass_idx = 'cohort_{}'.format(self.cohort.pk)
+
+        if not is_instructor and self.cohort and self.cohort.password and (
+                (pass_idx not in self.request.session) or
+                not self.password_match(
+                    self.cohort.password,
+                    self.request.session.get(pass_idx))):
+            # Password required. Redirect to password page.
+            url = reverse('cohort_password', kwargs={'pk': self.cohort.pk})
+            return HttpResponseRedirect(url)
+
+        return super(CohortPasswordMixin, self).dispatch(*args, **kwargs)
 
 
 class CohortInstructorMixin(object):
@@ -39,12 +79,7 @@ class CohortInstructorMixin(object):
         if not user_is_instructor(self.request.user):
             return HttpResponseForbidden()
 
-        cohort_pk = kwargs.get('cohort_pk', None)
-        pk = kwargs.get('pk', None)
-        if cohort_pk:
-            self.cohort = get_object_or_404(Cohort, pk=cohort_pk)
-        elif pk:
-            self.cohort = get_object_or_404(Cohort, pk=pk)
+        attach_cohort(self, **kwargs)
 
         if self.request.user not in self.cohort.instructors.all():
             return HttpResponseForbidden()

--- a/econplayground/templates/main/cohort_password_form.html
+++ b/econplayground/templates/main/cohort_password_form.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% load bootstrap4 %}
+
+{% block title %}Password Required{% endblock %}
+
+{% block content %}
+    <h1>Password Required</h1>
+    <p>
+        The instructor has set a password for this course.
+    </p>
+    <form class="form-group" method="post" action=".">{% csrf_token %}
+        <div class="form-group">
+            <input type="password" class="form-control"
+                   placeholder="Password" name="password" />
+        </div>
+        <div class="form-group">
+            <input class="btn btn-primary" type="submit"
+                   value="Submit" />
+        </div>
+    </form>
+{% endblock %}

--- a/econplayground/urls.py
+++ b/econplayground/urls.py
@@ -29,6 +29,8 @@ urlpatterns = [
          name='cohort_create'),
     path('course/<int:pk>/', views.CohortDetailView.as_view(),
          name='cohort_detail'),
+    path('course/<int:pk>/password/', views.CohortPasswordView.as_view(),
+         name='cohort_password'),
     path('course/<int:pk>/edit/', views.CohortUpdateView.as_view(),
          name='cohort_edit'),
     path('course/<int:pk>/graph/create/',


### PR DESCRIPTION
This replaces the LoginRequiredMixin with a new CohortPasswordMixin.

Courses are now public unless they have a password set. This facilitates
anonymous student use.

![2019-10-01-164142_482x373_scrot](https://user-images.githubusercontent.com/59292/65998935-609bcb80-e46a-11e9-86bf-fb40f9b64526.png)

