### PR TITLE
markdown: remove pyup pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==2.2.4
 pytz==2019.2
 httplib2==0.14.0
 feedparser==5.2.1
-Markdown==3.1.1 # pyup: < 3
+Markdown==3.1.1
 commonmark==0.9.0
 psycopg2==2.8.3
 Pillow==6.2.0


### PR DESCRIPTION
It looks like this wasn't even pinned anyways: markdown is at the latest version here.