### PR TITLE
Assessment admin: exclude 'graph' attribute - ECON-359

### DIFF
--- a/econplayground/main/admin.py
+++ b/econplayground/main/admin.py
@@ -47,6 +47,7 @@ class AssessmentRuleInline(admin.TabularInline):
 
 class AssessmentAdmin(admin.ModelAdmin):
     list_filter = ('graph__assignment_type', 'graph__title')
+    exclude = ('graph',)
     inlines = [
         AssessmentRuleInline,
     ]


### PR DESCRIPTION
I'm now linking directly to the graph's assessment, and there's no need
for the graphs dropdown here.