### PR TITLE
Add support for the instructors group - ECON-365

### DIFF
--- a/econplayground/main/tests/test_utils.py
+++ b/econplayground/main/tests/test_utils.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from econplayground.main.utils import user_is_instructor
+from econplayground.main.tests.factories import (
+    InstructorFactory, StudentFactory
+)
+
+
+class UtilsTest(TestCase):
+    def setUp(self):
+        self.instructor = InstructorFactory()
+        self.student = StudentFactory()
+
+    def test_user_is_instructors(self):
+        self.assertTrue(user_is_instructor(self.instructor))
+        self.assertFalse(user_is_instructor(self.student))

--- a/econplayground/main/utils.py
+++ b/econplayground/main/utils.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.auth.models import Group
 
 INSTRUCTOR_LIST = ['tg2451']
 
@@ -10,4 +11,12 @@ def user_is_instructor(user):
     except AttributeError:
         instructor_list = INSTRUCTOR_LIST
 
-    return (user.username in instructor_list) or user.is_staff
+    try:
+        instructors_group = Group.objects.get(name='instructors')
+    except Group.DoesNotExist:
+        instructors_group = None
+
+    return (instructors_group and
+            (instructors_group in user.groups.all())) or \
+        (user.username in instructor_list) or \
+        user.is_staff


### PR DESCRIPTION
I've added a new "instructors" group in the django admin, with the
appropriate permissions set. I'm leaving the old INSTRUCTORS_LIST
functionality in here for now, but I can eventually remove it.