### PR TITLE
Remove django-jenkins

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -19,7 +19,7 @@ REQUIREMENTS ?= requirements.txt
 SYS_PYTHON ?= python3
 PY_SENTINAL ?= $(VE)/sentinal
 WHEEL_VERSION ?= 0.33.6
-PIP_VERSION ?= 19.3
+PIP_VERSION ?= 19.3.1
 MAX_COMPLEXITY ?= 10
 INTERFACE ?= localhost
 RUNSERVER_PORT ?= 8000
@@ -31,10 +31,12 @@ ifeq ($(TRAVIS),true)
 	BANDIT ?= bandit
 	FLAKE8 ?= flake8
 	PIP ?= pip
+	COVERAGE ?= coverage
 else
 	BANDIT ?= $(VE)/bin/bandit
 	FLAKE8 ?= $(VE)/bin/flake8
 	PIP ?= $(VE)/bin/pip
+	COVERAGE ?= $(VE)/bin/coverage
 endif
 
 jenkins: check flake8 test eslint bandit
@@ -49,7 +51,8 @@ $(PY_SENTINAL): $(REQUIREMENTS)
 	touch $@
 
 test: $(PY_SENTINAL)
-	$(MANAGE) jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc
+	$(COVERAGE) run --source='.' $(MANAGE) test $(APP)
+	$(COVERAGE) xml -o reports/coverage.xml
 
 parallel-tests: $(PY_SENTINAL)
 	$(MANAGE) test --parallel

--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -48,7 +48,6 @@ INSTALLED_APPS = [  # noqa
     'django.contrib.admindocs',
     'django_statsd',
     'smoketest',
-    'django_jenkins',
     'gunicorn',
     'compressor',
     'djangowind',

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,6 @@ sentry-sdk==0.14.0
 django-bootstrap4==1.1.1
 django-debug-toolbar==2.1
 django-waffle==0.19.0
-django-jenkins==0.110.0
 django-smoketest==1.1.0
 
 django-extensions==2.2.6


### PR DESCRIPTION
Run coverage without django-jenkins. Using instructions from here:
https://docs.djangoproject.com/en/3.0/topics/testing/advanced/#integration-with-coverage-py

I'll add this to our common makefiles as well.