### PR TITLE
:arrow_up: cryptography 3.4.4

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -50,7 +50,7 @@ $(PY_SENTINAL): $(REQUIREMENTS)
 	$(PIP) install pip==$(PIP_VERSION)
 	$(PIP) install --upgrade setuptools
 	$(PIP) install wheel==$(WHEEL_VERSION)
-	$(PIP) install --no-deps --requirement $(REQUIREMENTS) --no-binary cryptography
+	$(PIP) install --no-deps --requirement $(REQUIREMENTS)
 	touch $@
 
 test: $(PY_SENTINAL)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ fuzzywuzzy==0.18.0
 sure==1.4.11
 coverage==5.4
 asn1crypto==1.4.0  # cryptography
-cryptography==3.3.2
+cryptography==3.4.4
 urllib3==1.26.3  # requests, sentry-sdk
 chardet==4.0.0  # requests
 idna==3.1  # requests


### PR DESCRIPTION
Removing the --no-binary flag for cryptography, using pre-built Linux
wheel works in my dev environment. Let's see if it works in production.