### PR TITLE
Use normal text input widget in Assignment Create view

### DIFF
--- a/econplayground/main/views.py
+++ b/econplayground/main/views.py
@@ -1,5 +1,6 @@
 import hashlib
 from braces.views import CsrfExemptMixin
+from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import (
     LoginRequiredMixin, UserPassesTestMixin
@@ -666,6 +667,11 @@ class AssignmentCreateView(
     model = Assignment
     fields = ['title', 'prompt', 'banks', 'cohorts']
     template_name = 'main/assignment_form.html'
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields['title'].widget = forms.TextInput()
+        return form
 
     def get(self, request, *args, **kwargs):
         self.is_assignment = True


### PR DESCRIPTION
We don't need a full textarea here. We can override django's form [widgets](https://docs.djangoproject.com/en/4.1/ref/forms/widgets/) that it infers based on the model's types.

https://stackoverflow.com/a/57748652/173630