### PR TITLE
QuestionBank / Question forms: use custom form class

### DIFF
--- a/econplayground/main/forms.py
+++ b/econplayground/main/forms.py
@@ -1,5 +1,7 @@
 from django import forms
-from econplayground.main.models import Cohort, Assignment
+from econplayground.main.models import (
+    Cohort, Assignment, Question, QuestionBank
+)
 
 
 class CohortCloneForm(forms.Form):
@@ -32,6 +34,16 @@ class AssignmentCloneForm(forms.Form):
         return r
 
 
+class QuestionBankForm(forms.ModelForm):
+    class Meta:
+        model = QuestionBank
+        fields = ('title', 'assignment', 'description',
+                  'questions', 'supplemental')
+        widgets = {
+            'title': forms.TextInput(),
+        }
+
+
 class QuestionBankCloneForm(forms.Form):
     title = forms.CharField()
     assignment = forms.ModelChoiceField(Assignment.objects.none())
@@ -43,6 +55,17 @@ class QuestionBankCloneForm(forms.Form):
             instructor__in=(user,))
 
         return r
+
+
+class QuestionForm(forms.ModelForm):
+    class Meta:
+        model = Question
+        fields = (
+            'title', 'prompt', 'embedded_media', 'graph'
+        )
+        widgets = {
+            'title': forms.TextInput(),
+        }
 
 
 class QuestionCloneForm(forms.Form):

--- a/econplayground/main/views.py
+++ b/econplayground/main/views.py
@@ -22,7 +22,8 @@ from lti_provider.views import LTILandingPage
 
 from econplayground.main.forms import (
     CohortCloneForm, GraphCloneForm, AssignmentCloneForm,
-    QuestionBankCloneForm, QuestionCloneForm
+    QuestionBankForm, QuestionBankCloneForm,
+    QuestionForm, QuestionCloneForm
 )
 from econplayground.main.mixins import (
     CohortGraphMixin, CohortPasswordMixin,
@@ -905,8 +906,8 @@ class QuestionBankCreateView(
         EnsureCsrfCookieMixin, UserPassesTestMixin,
         LoginRequiredMixin, CreateView):
     model = QuestionBank
-    fields = ['title', 'assignment', 'description',
-              'questions', 'supplemental']
+    form_class = QuestionBankForm
+
     is_assignment = False
     is_question_bank = True
     is_question = False
@@ -1124,9 +1125,8 @@ class QuestionCreateView(
         EnsureCsrfCookieMixin, UserPassesTestMixin,
         LoginRequiredMixin, CreateView):
     model = Question
-    fields = [
-        'title', 'prompt', 'embedded_media', 'graph'
-    ]
+    form_class = QuestionForm
+
     is_assignment = False
     is_question_bank = False
     is_question = True


### PR DESCRIPTION
So we can use the TextInput widget for the title rather than a Textarea, and make further changes as needed here.