### PR TITLE
Add rich for bandit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -97,6 +97,7 @@ django-smtp-ssl==1.0
 django-contact-us==1.1.0
 docutils==0.19  # Django's admindocs
 
+rich==13.3.2  # bandit
 pbr==5.11.1  # bandit
 pyyaml==6.0  # bandit
 stevedore==5.0.0  # bandit


### PR DESCRIPTION
Looks like this new version of bandit requires a new package, causing the recent failures on jenkins. https://github.com/PyCQA/bandit/releases/tag/1.7.5