### PR TITLE
Fix JS build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build-scss": "node-sass --output media/css media/scss/main.scss --output-style compressed",
     "watch-scss": "nodemon --watch media/scss --verbose -e scss -x 'npm run build-scss'",
     "dev": "webpack --mode development --watch --config media/js/config/webpack.config.dev.js",
-    "build": "node media/js/scripts/build.js",
+    "build": "NODE_ENV=production webpack --mode production --config media/js/config/webpack.config.prod.js",
     "eslint": "eslint media/js/src/*.js media/js/config/*.js"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm run build` should run webpack with the prod configuration. This should fix an error I ran into with the automated build in jenkins:

```
Failed to compile.

configuration
The 'mode' option has not been set, webpack will fallback to
'production' for this value.
Set 'mode' option to 'development' or 'production' to enable defaults
for each environment.
    You can also set it to 'none' to disable any default behavior. Learn
    more: https://webpack.js.org/configuration/mode/

```