### PR TITLE
Fix github actions issue with running on multiple pythons

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,10 +6,13 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-          python-version: [3.8, "3.11"]
+          python-version: ['3.8', '3.11']
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Flake8
         run: make flake8
       - name: Test


### PR DESCRIPTION
Python 3.11 wasn't being tested: the github actions docker image was just using ubuntu 20.04's default python - version 3.8.

I've followed some steps here to get this working like we want: 
* https://github.com/actions/setup-python
* https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python