### PR TITLE
Migrate to psycopg 3.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytz==2023.3
 httplib2==0.22.0
 feedparser==6.0.10
 Markdown==3.4.3
-psycopg2==2.9.6
+psycopg[binary]==3.1.9
 versiontools==1.9.1
 statsd==4.0.1
 pep8==1.7.1


### PR DESCRIPTION
Django 4.2 adds support for psycopg version 3:
https://docs.djangoproject.com/en/4.2/releases/4.2/#psycopg-3-support

It looks like the recommended way to install this package is via the binary package:
https://www.psycopg.org/psycopg3/docs/basic/install.html

This method has its advantages and disadvantages. Sometimes it's more reliable to not use a binary package and build from source, but we'll see if we run into any issues here and we can adjust as needed.