### PR TITLE
Fix flatpages display

### DIFF
--- a/econplayground/templates/base.html
+++ b/econplayground/templates/base.html
@@ -102,10 +102,10 @@
                                     {% endif %}
                                 {% endif %}
                                 <li class="nav-item">
-                                    <a class="nav-link" title="Help" href="/help/">Help</a>
+                                    <a class="nav-link" title="Help" href="/pages/help/">Help</a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link" title="About" href="/about/">About</a>
+                                    <a class="nav-link" title="About" href="/pages/about/">About</a>
                                 </li>
                                 <li class="nav-item">
                                     {% if request.user.is_anonymous %}

--- a/econplayground/templates/flatpages/default.html
+++ b/econplayground/templates/flatpages/default.html
@@ -5,5 +5,5 @@
 {% block pagetitle %}<h1 class="mt-4">{{ flatpage.title }}</h1>{% endblock %}
 
 {% block content %}
-{{ flatpage.content|markdown}}
+{{ flatpage.content }}
 {% endblock %}

--- a/econplayground/urls.py
+++ b/econplayground/urls.py
@@ -176,6 +176,8 @@ urlpatterns = [
     path('contact/', include('contactus.urls')),
 
     path('sentry-debug/', trigger_error),
+
+    path('pages/', include('django.contrib.flatpages.urls')),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
* Don't rely on FlatpageFallbackMiddleware for routing - this seems to break in production. Instead, explicitly route the flat pages at the `/pages/` root.
* Remove unused `markdown` template tag in flatpage rendering. We are using html within the flatpage content and this markdown tag causes an error.