### PR TITLE
Remove form-control-sm from custom RangeEditor

### DIFF
--- a/media/js/src/form-components/RangeEditor.js
+++ b/media/js/src/form-components/RangeEditor.js
@@ -25,7 +25,7 @@ export default class RangeEditor extends React.Component {
                             </div>
                         )}
                         <input
-                            className="d-inline form-range form-control-sm w-90"
+                            className="d-inline form-range w-90"
                             aria-label={this.props.note}
                             id={this.props.id}
                             data-id={this.props.dataId}


### PR DESCRIPTION
Minor style adjustment - this just removes some extra padding from this input. I don't think this class was really meant to be used on bootstrap's custom form-range input.