### PR TITLE
Add fixed bg color to jsxgraph display

### DIFF
--- a/econplayground/templates/base.html
+++ b/econplayground/templates/base.html
@@ -47,7 +47,7 @@
     <link href="{{STATIC_URL}}css/main.css" rel="stylesheet">
     <link href="{{STATIC_URL}}css/octicons.css" rel="stylesheet">
     {% endcompress %}
-    <link href="{% static 'css/epjs.css' %}" rel="stylesheet">
+    <link href="{% static 'css/econplayground.css' %}" rel="stylesheet">
     {% block css %}{% endblock %}
     {% block extrahead %}{% endblock %}
 

--- a/econplayground/templates/main/graph_detail.html
+++ b/econplayground/templates/main/graph_detail.html
@@ -5,7 +5,6 @@
 
 {% block css %}
 <link rel="stylesheet" href="{% static 'css/loaders.min.css' %}">
-<link rel="stylesheet" href="{% static 'css/epjs.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/econplayground/templates/main/graph_embed.html
+++ b/econplayground/templates/main/graph_embed.html
@@ -5,7 +5,7 @@
         <title>Graph: {{object.title}}</title>
         <link href="{% static 'css/main.css' %}" rel="stylesheet">
         <link href="{% static 'css/embed.css' %}" rel="stylesheet">
-        <link rel="stylesheet" href="{% static 'css/epjs.css' %}">
+        <link rel="stylesheet" href="{% static 'css/econplayground.css' %}">
         <meta id="csrf-token" name="csrf-token" content="{{csrf_token}}">
     </head>
     <body>

--- a/econplayground/templates/main/graph_embed_public.html
+++ b/econplayground/templates/main/graph_embed_public.html
@@ -7,7 +7,6 @@
     <link href="{% static 'css/main.css' %}" rel="stylesheet">
     <link href="{% static 'css/embed.css' %}" rel="stylesheet">
     <link href="{% static 'css/octicons.css' %}" rel="stylesheet">
-    <link rel="stylesheet" href="{% static 'css/epjs.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/econplayground/templates/main/graph_embed_public_minimal.html
+++ b/econplayground/templates/main/graph_embed_public_minimal.html
@@ -6,7 +6,7 @@
         <link href="{% static 'css/main.css' %}" rel="stylesheet">
         <link href="{% static 'css/embed.css' %}" rel="stylesheet">
         <link href="{% static 'css/octicons.css' %}" rel="stylesheet">
-        <link rel="stylesheet" href="{% static 'css/epjs.css' %}">
+        <link rel="stylesheet" href="{% static 'css/econplayground.css' %}">
         <meta id="csrf-token" name="csrf-token" content="{{csrf_token}}">
     </head>
     <body>

--- a/econplayground/templates/main/graph_form.html
+++ b/econplayground/templates/main/graph_form.html
@@ -3,7 +3,6 @@
 
 {% block css %}
 <link rel="stylesheet" href="{% static 'css/loaders.min.css' %}">
-<link rel="stylesheet" href="{% static 'css/epjs.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/econplayground/templates/main/question_bank_detail.html
+++ b/econplayground/templates/main/question_bank_detail.html
@@ -7,7 +7,6 @@
     <link href="{% static 'css/main.css' %}" rel="stylesheet">
     <link href="{% static 'css/embed.css' %}" rel="stylesheet">
     <link href="{% static 'css/octicons.css' %}" rel="stylesheet">
-    <link rel="stylesheet" href="{% static 'css/epjs.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/econplayground/templates/main/question_detail.html
+++ b/econplayground/templates/main/question_detail.html
@@ -7,7 +7,6 @@
     <link href="{% static 'css/main.css' %}" rel="stylesheet">
     <link href="{% static 'css/embed.css' %}" rel="stylesheet">
     <link href="{% static 'css/octicons.css' %}" rel="stylesheet">
-    <link rel="stylesheet" href="{% static 'css/epjs.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/econplayground/templates/main/question_form.html
+++ b/econplayground/templates/main/question_form.html
@@ -3,7 +3,6 @@
 
 {% block css %}
 <link rel="stylesheet" href="{% static 'css/loaders.min.css' %}">
-<link rel="stylesheet" href="{% static 'css/epjs.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/econplayground/templates/main/question_student.html
+++ b/econplayground/templates/main/question_student.html
@@ -7,7 +7,6 @@
     <link href="{% static 'css/main.css' %}" rel="stylesheet">
     <link href="{% static 'css/embed.css' %}" rel="stylesheet">
     <link href="{% static 'css/octicons.css' %}" rel="stylesheet">
-    <link rel="stylesheet" href="{% static 'css/epjs.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/econplayground/templates/main/question_student_ALT.html
+++ b/econplayground/templates/main/question_student_ALT.html
@@ -3,7 +3,6 @@
 
 {% block css %}
 <link rel="stylesheet" href="{% static 'css/loaders.min.css' %}">
-<link rel="stylesheet" href="{% static 'css/epjs.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/media/css/econplayground.css
+++ b/media/css/econplayground.css
@@ -1,3 +1,8 @@
+/*
+ Basic CSS customizations for EconPractice - for if you don't want to
+ get into scss.
+ */
+
 .nav-link {
     color: white;
 }
@@ -14,4 +19,8 @@
 
 .ep-max {
     margin-left: 10px;
+}
+
+figure#editing-graph {
+    background-color: white;
 }


### PR DESCRIPTION
This alleviates issue #2271.

It's not solved completely, but I think the SVG display area should have a hard-coded color as a background. We are hard-coding all the line colors themselves, so it's really designed with a white background in mind.

Additionally, this CSS file was being included redundantly in many templates: it only needs to be included in base.html if the template inherits from base.