### PR TITLE
Move CUIT privacy notice to login page

### DIFF
--- a/econplayground/templates/base.html
+++ b/econplayground/templates/base.html
@@ -62,9 +62,6 @@
 
     <!-- Font -->
     <link href="https://fonts.googleapis.com/css?family=Quattrocento+Sans" rel="stylesheet">
-
-    <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
-    <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
 </head>
 
 {% user_is_instructor request.user as i_am_instructor %}

--- a/econplayground/templates/registration/login.html
+++ b/econplayground/templates/registration/login.html
@@ -11,6 +11,11 @@
     {% endcompress %}
 {% endblock %}
 
+{% block js %}
+    <link rel="stylesheet" href="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.css" />
+    <script src="https://search.sites.columbia.edu/cu-privacy-notice/cu-privacy-notice.js"></script>
+{% endblock %}
+
 {% block bodyclass %}splash{% endblock %}
 {% block main-class %}{% endblock %}
 


### PR DESCRIPTION
This really doesn't need to display on every page, and just causes an annoyance with the page refreshes in new assignment form. Even when you have the pop-up disabled, it will display briefly as the page loads, before the JS has a chance to hide it.

So, just keep this on the login page for now.

And, as far as the public student graph view, we aren't using any cookie or login data here so it's really not relevant.