### PR TITLE
Implement custom graph viewer for assignment steps

### DIFF
--- a/econplayground/templates/assignment/step_detail.html
+++ b/econplayground/templates/assignment/step_detail.html
@@ -28,13 +28,11 @@
             window.EconPlayground = {};
         }
 
-        window.EconPlayground['isInstructor'] = false;
-        window.EconPlayground['hideTitleAndInstructions'] = true;
         {% if object.question and object.question.graph %}
             window.GRAPH_ID = {{object.question.graph.pk}};
         {% endif %}
     </script>
-    <script src="{% static 'js/build/viewer.js' %}"></script>
+    <script src="{% static 'js/build/stepGraphViewer.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -45,15 +43,16 @@
                 {{object.question.prompt}}
             </p>
 
-            <div id="root">
-                <div class="loader-inner ball-pulse">
-                    <div></div>
-                    <div></div>
-                    <div></div>
-                </div>
-            </div>
-
             <form action="post">
+                <div id="root">
+                    <div class="loader-inner ball-pulse">
+                        <div></div>
+                        <div></div>
+                        <div></div>
+                    </div>
+                </div>
+
+
                 {% csrf_token %}
                 <button type="submit" class="btn btn-primary">
                     Submit

--- a/media/js/config/paths.cjs
+++ b/media/js/config/paths.cjs
@@ -51,6 +51,7 @@ module.exports = {
     appHtml: resolveApp(JS_PATH + 'public/index.html'),
     appEditorJs: resolveApp(JS_PATH + 'src/editor-main.js'),
     appViewerJs: resolveApp(JS_PATH + 'src/viewer-main.js'),
+    appStepGraphViewerJs: resolveApp(JS_PATH + 'src/stepGraphViewer-main.js'),
     appQuestionJs: resolveApp(JS_PATH + 'src/question-main.js'),
     appAssignmentJs: resolveApp(JS_PATH + 'src/assignment-main.js'),
     appPackageJson: resolveApp('package.json'),

--- a/media/js/config/webpack.config.dev.cjs
+++ b/media/js/config/webpack.config.dev.cjs
@@ -34,6 +34,7 @@ module.exports = {
         assignment: [paths.appAssignmentJs],
         editor: [paths.appEditorJs],
         question: [paths.appQuestionJs],
+        stepGraphViewer: [paths.appStepGraphViewerJs],
         viewer: [paths.appViewerJs]
     },
     output: {

--- a/media/js/config/webpack.config.prod.cjs
+++ b/media/js/config/webpack.config.prod.cjs
@@ -39,6 +39,7 @@ module.exports = {
         assignment: [paths.appAssignmentJs],
         editor: [paths.appEditorJs],
         question: [paths.appQuestionJs],
+        stepGraphViewer: [paths.appStepGraphViewerJs],
         viewer: [paths.appViewerJs]
     },
     output: {

--- a/media/js/scripts/build.js
+++ b/media/js/scripts/build.js
@@ -38,8 +38,11 @@ const WARN_AFTER_BUNDLE_GZIP_SIZE = 512 * 1024;
 const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024;
 
 // Warn and crash if required files are missing
-if (!checkRequiredFiles([paths.appHtml, paths.appEditorJs, paths.appQuestionJs, paths.appViewerJs])) {
-  process.exit(1);
+if (!checkRequiredFiles([
+    paths.appHtml, paths.appEditorJs, paths.appQuestionJs, paths.appViewerJs,
+    paths.appStepGraphViewerJs
+])) {
+    process.exit(1);
 }
 
 // First, read the current file sizes in build directory.

--- a/media/js/src/GraphMapping.js
+++ b/media/js/src/GraphMapping.js
@@ -222,7 +222,7 @@ const convertGraph = function(json) {
 /**
  * Import the json graph into the current state.
  */
-const importGraph = function(json, obj) {
+const importGraph = function(json, obj, callback=null) {
     const updateObj = {
         gId: json.id,
         gTitle: json.title,
@@ -340,7 +340,9 @@ const importGraph = function(json, obj) {
         updateObj.gA3 = 0.5;
     }
 
-    return obj.setState(Object.assign({}, updateObj, initialStateObj));
+    return obj.setState(
+        Object.assign({}, updateObj, initialStateObj),
+        callback);
 };
 
 const defaultEvaluation = {

--- a/media/js/src/StepGraphViewer.jsx
+++ b/media/js/src/StepGraphViewer.jsx
@@ -1,0 +1,162 @@
+import React, { Component } from 'react';
+import { defaultGraph, importGraph } from './GraphMapping.js';
+import ResetGraphButton from './buttons/ResetGraphButton.jsx';
+import JXGBoard from './JXGBoard.jsx';
+import {
+    authedFetch, BOARD_WIDTH, BOARD_HEIGHT
+} from './utils.js';
+
+/**
+ * StepGraphViewer
+ *
+ * This component is intended to be used in an Assignment Step. Basically,
+ * just render the graph with no surrounding assessment stuff - let all
+ * that be handled in Django.
+ */
+export default class StepGraphViewer extends Component {
+    constructor(props) {
+        super(props);
+
+        if (window.GRAPH_ID) {
+            this.graphId = window.GRAPH_ID;
+        }
+
+        this.state = {
+            initialState: {},
+            actions: []
+        };
+        this.state = Object.assign(this.state, defaultGraph);
+    }
+
+    getGraph() {
+        const me = this;
+        return authedFetch(`/api/graphs/${this.graphId}/`)
+            .then(function(response) {
+                return response.json();
+            }).then(function(json) {
+                importGraph(json, me, function() {
+                    let initialState = me.state.initialState;
+
+                    // Handle initialState weirdness so the reset
+                    // button works properly.
+                    let key = '';
+                    for (key in me.state) {
+                        if (key.endsWith('Initial')) {
+                            initialState[key.replace(/Initial$/, '')] =
+                                me.state[key];
+                        }
+                    }
+                    me.setState({initialState: initialState});
+                });
+            });
+    }
+
+    componentDidMount() {
+        this.getGraph();
+
+        const me = this;
+        document.addEventListener('l1offset', function(e) {
+            const offset = e.detail;
+            let line = 1;
+            if (e.detail.line) {
+                line = e.detail.line;
+            }
+
+            let actions = [...me.state.actions, {
+                key: Date.now(),
+                name: 'line1',
+                value: 'change'
+            }];
+
+            me.setState({
+                [`gLine${line}OffsetX`]: offset.x,
+                [`gLine${line}OffsetY`]: offset.y,
+                actions: actions
+            });
+        });
+
+        document.addEventListener('l2offset', function(e) {
+            const offset = e.detail;
+            let line = 2;
+            if (e.detail.line) {
+                line = e.detail.line;
+            }
+
+            let actions = [...me.state.actions, {
+                key: Date.now(),
+                name: 'line2',
+                value: 'change'
+            }];
+
+            me.setState({
+                [`gLine${line}OffsetX`]: offset.x,
+                [`gLine${line}OffsetY`]: offset.y,
+                actions: actions
+            });
+        });
+
+        document.addEventListener('l3offset', function(e) {
+            const offset = e.detail;
+
+            let actions = [...me.state.actions, {
+                key: Date.now(),
+                name: 'line3',
+                value: 'change'
+            }];
+
+            me.setState({
+                gLine3OffsetX: offset.x,
+                gLine3OffsetY: offset.y,
+                actions: actions
+            });
+        });
+    }
+
+    render() {
+        let leftSide = (
+            <p>Loading...</p>
+        );
+        if (
+            typeof this.state.gType !== 'undefined' &&
+                this.state.gType !== null
+        ) {
+            leftSide = (
+                <JXGBoard
+                    id={'editing-graph'}
+                    width={BOARD_WIDTH}
+                    height={BOARD_HEIGHT}
+                    shadow={true}
+                    {...this.state}
+                />
+            );
+        }
+
+        const rightSide = <p>rightSide</p>;
+
+        return (
+            <div className="GraphViewer">
+                <div className="row">
+                    <div className="col">
+                        <div className="sticky-top">
+                            {leftSide}
+                        </div>
+                    </div>
+
+                    <div className="col">
+                        {rightSide}
+
+                        <ResetGraphButton
+                            initialState={this.state.initialState}
+                            updateGraph={this.setState.bind(this)} />
+                    </div>
+                </div>
+                {this.state.actions.map((action) => (
+                    <input
+                        type="hidden"
+                        key={action.key}
+                        name={action.name} value={action.value} />
+                ))}
+            </div>
+        );
+    }
+}

--- a/media/js/src/stepGraphViewer-main.js
+++ b/media/js/src/stepGraphViewer-main.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import StepGraphViewer from './StepGraphViewer.jsx';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<StepGraphViewer />);


### PR DESCRIPTION
This React view had to be customized a bit, because I'm not planning on directly using the existing Assessment.js form stuff. I want just a more minimal react view here, so we can handle all the submission stuff in Django. Also, we don't need to differentiate between instructor/student in this view, so a lot can be simplified here.

I've added some basic 'actions' events on line move, which create hidden input fields which can be used for evaluation on submit. Eventually this can be expanded to all fields.