### PR TITLE
Put RangeEditor controls in a horizontal grid

### DIFF
--- a/media/js/src/form-components/RangeEditor.js
+++ b/media/js/src/form-components/RangeEditor.js
@@ -10,156 +10,166 @@ import { btnStep } from '../utils.js';
  */
 export default class RangeEditor extends React.Component {
     render() {
-        return <React.Fragment>
-            <div className="form-row slider-wrapper">
-                <label key="dataId" className="w-100" htmlFor={this.props.id}>
-                    {this.props.itemlabel && (
-                        <div style={{display: 'flex'}}>
-                            <MathComponent tex={this.props.itemlabel} />
+        return (
+            <React.Fragment>
+                <div className="row">
+                    <div className="col">
+                        <div className="form-row slider-wrapper">
+                            <label key="dataId" className="w-100" htmlFor={this.props.id}>
+                                {this.props.itemlabel && (
+                                    <div style={{display: 'flex'}}>
+                                        <MathComponent tex={this.props.itemlabel} />
+                                    </div>
+                                )}
+
+                                <div className="d-inline w-100">
+                                    {this.props.showMinMax && (
+                                        <div className="position-absolute l-0">
+                                            {this.props.min}
+                                        </div>
+                                    )}
+                                    <input
+                                        className="d-inline form-range w-90"
+                                        aria-label={this.props.note}
+                                        id={this.props.id}
+                                        data-id={this.props.dataId}
+                                        type="range"
+                                        onChange={this.props.handler}
+                                        value={this.props.value}
+                                        step={this.props.step || 0.01}
+                                        min={this.props.min}
+                                        max={this.props.max}
+                                    />
+                                    {this.props.showMinMax && (
+                                        <div className="d-inline position-absolute r-0">
+                                            {this.props.max}
+                                        </div>
+                                    )}
+                                </div>
+                            </label>
                         </div>
-                    )}
-                    <div className="d-inline w-100">
-                        {this.props.showMinMax && (
-                            <div className="position-absolute l-0">
-                                {this.props.min}
+                    </div>
+                    <div className="col">
+                        <div className="mb-2 input-group">
+                            <button
+                                className="btn btn-sm btn-primary ms-1 w-20"
+                                aria-label={'Decrease by ' + (Number(this.props.step) * 10 || 0.1)}
+                                id={this.props.id}
+                                data-id={this.props.dataId}
+                                type="button"
+                                onClick={this.props.handler}
+                                value={
+                                    btnStep(
+                                        this.props.value,
+                                        -1,
+                                        this.props.step * 10 || 0.1,
+                                        this.props.min,
+                                        this.props.max)
+                                }>
+                                &lt;&lt;&lt;
+                            </button>
+                            <button
+                                className="btn btn-sm btn-info ms-1 w-20"
+                                aria-label={'Decrease by ' + (Number(this.props.step) || 0.01)}
+                                id={this.props.id}
+                                data-id={this.props.dataId}
+                                type="button"
+                                onClick={this.props.handler}
+                                value={
+                                    btnStep(
+                                        this.props.value,
+                                        -1,
+                                        this.props.step || 0.01,
+                                        this.props.min,
+                                        this.props.max)
+                                }>
+                                &lt;
+                            </button>
+                            <button
+                                className="btn btn-sm btn-info ms-1 w-20"
+                                aria-label={'Increase by ' + (Number(this.props.step) || 0.01)}
+                                id={this.props.id}
+                                data-id={this.props.dataId}
+                                type="button"
+                                onClick={this.props.handler}
+                                value={
+                                    btnStep(
+                                        this.props.value,
+                                        1,
+                                        this.props.step || 0.01,
+                                        this.props.min,
+                                        this.props.max)
+                                }>
+                                &gt;
+                            </button>
+                            <button
+                                className="btn btn-sm btn-primary ms-1 w-20"
+                                aria-label={'Increase by ' + (Number(this.props.step) * 10 || 0.1)}
+                                id={this.props.id}
+                                data-id={this.props.dataId}
+                                type="button"
+                                onClick={this.props.handler}
+                                value={
+                                    btnStep(
+                                        this.props.value,
+                                        1,
+                                        this.props.step * 10 || 0.1,
+                                        this.props.min,
+                                        this.props.max)
+                                }>
+                                &gt;&gt;&gt;
+                            </button>
+                            <input
+                                className="form-control ms-1"
+                                aria-label={'Input: ' + this.props.value}
+                                type="number"
+                                id={this.props.id}
+                                data-id={this.props.dataId}
+                                value={this.props.value}
+                                step={Number(this.props.step) || 0.01}
+                                onChange={this.props.handler}
+                                min={this.props.min}
+                                max={this.props.max}>
+                            </input>
+                        </div>
+                    </div>
+
+                    <div className="input-group">
+                        {this.props.showOverrideButton && (
+                            <div className="form-check form-check-inline">
+                                <label className="form-check-label">
+                                    <input
+                                        data-id={this.props.dataId}
+                                        data-override={this.props.overrideValue}
+                                        className="form-check-input override"
+                                        type="radio"
+                                        onChange={this.props.handler}
+                                        checked={this.props.value === this.props.overrideValue} />
+                                    {this.props.overrideLabel}
+                                </label>
                             </div>
                         )}
-                        <input
-                            className="d-inline form-range w-90"
-                            aria-label={this.props.note}
-                            id={this.props.id}
-                            data-id={this.props.dataId}
-                            type="range"
-                            onChange={this.props.handler}
-                            value={this.props.value}
-                            step={this.props.step || 0.01}
-                            min={this.props.min}
-                            max={this.props.max}
-                        />
-                        {this.props.showMinMax && (
-                            <div className="d-inline position-absolute r-0">
-                                {this.props.max}
+                        {this.props.showOverride2Button && (
+                            <div className="form-check form-check-inline">
+                                <label className="form-check-label">
+                                    <input
+                                        data-id={this.props.dataId}
+                                        data-override={this.props.override2Value}
+                                        className="form-check-input override"
+                                        type="radio"
+                                        onChange={this.props.handler}
+                                        checked={this.props.value === this.props.override2Value} />
+                                    {this.props.override2Label}
+                                </label>
                             </div>
                         )}
                     </div>
-                </label>
-                <div className="mb-2 input-group">
-                    <button
-                        className="btn btn-sm btn-primary ms-1 w-20"
-                        aria-label={'Decrease by ' + (Number(this.props.step) * 10 || 0.1)}
-                        id={this.props.id}
-                        data-id={this.props.dataId}
-                        type="button"
-                        onClick={this.props.handler}
-                        value={
-                            btnStep(
-                                this.props.value,
-                                -1,
-                                this.props.step * 10 || 0.1,
-                                this.props.min,
-                                this.props.max)
-                        }>
-                        &lt;&lt;&lt;
-                    </button>
-                    <button
-                        className="btn btn-sm btn-info ms-1 w-20"
-                        aria-label={'Decrease by ' + (Number(this.props.step) || 0.01)}
-                        id={this.props.id}
-                        data-id={this.props.dataId}
-                        type="button"
-                        onClick={this.props.handler}
-                        value={
-                            btnStep(
-                                this.props.value,
-                                -1,
-                                this.props.step || 0.01,
-                                this.props.min,
-                                this.props.max)
-                        }>
-                        &lt;
-                    </button>
-                    <button
-                        className="btn btn-sm btn-info ms-1 w-20"
-                        aria-label={'Increase by ' + (Number(this.props.step) || 0.01)}
-                        id={this.props.id}
-                        data-id={this.props.dataId}
-                        type="button"
-                        onClick={this.props.handler}
-                        value={
-                            btnStep(
-                                this.props.value,
-                                1,
-                                this.props.step || 0.01,
-                                this.props.min,
-                                this.props.max)
-                        }>
-                        &gt;
-                    </button>
-                    <button
-                        className="btn btn-sm btn-primary ms-1 w-20"
-                        aria-label={'Increase by ' + (Number(this.props.step) * 10 || 0.1)}
-                        id={this.props.id}
-                        data-id={this.props.dataId}
-                        type="button"
-                        onClick={this.props.handler}
-                        value={
-                            btnStep(
-                                this.props.value,
-                                1,
-                                this.props.step * 10 || 0.1,
-                                this.props.min,
-                                this.props.max)
-                        }>
-                        &gt;&gt;&gt;
-                    </button>
-                    <input
-                        className="form-control ms-1"
-                        aria-label={'Input: ' + this.props.value}
-                        type="number"
-                        id={this.props.id}
-                        data-id={this.props.dataId}
-                        value={this.props.value}
-                        step={Number(this.props.step) || 0.01}
-                        onChange={this.props.handler}
-                        min={this.props.min}
-                        max={this.props.max}>
-                    </input>
+                    <small className="form-text text-muted ms-sm-2">
+                        {this.props.note}
+                    </small>
                 </div>
-                <div className="input-group">
-                    {this.props.showOverrideButton && (
-                        <div className="form-check form-check-inline">
-                            <label className="form-check-label">
-                                <input
-                                    data-id={this.props.dataId}
-                                    data-override={this.props.overrideValue}
-                                    className="form-check-input override"
-                                    type="radio"
-                                    onChange={this.props.handler}
-                                    checked={this.props.value === this.props.overrideValue} />
-                                {this.props.overrideLabel}
-                            </label>
-                        </div>
-                    )}
-                    {this.props.showOverride2Button && (
-                        <div className="form-check form-check-inline">
-                            <label className="form-check-label">
-                                <input
-                                    data-id={this.props.dataId}
-                                    data-override={this.props.override2Value}
-                                    className="form-check-input override"
-                                    type="radio"
-                                    onChange={this.props.handler}
-                                    checked={this.props.value === this.props.override2Value} />
-                                {this.props.override2Label}
-                            </label>
-                        </div>
-                    )}
-                </div>
-                <small className="form-text text-muted ms-sm-2">
-                    {this.props.note}
-                </small>
-            </div>
-        </React.Fragment>;
+            </React.Fragment>
+        );
     }
 }
 


### PR DESCRIPTION
I noticed there's a lot of extra horizontal space with the new RangeEditor buttons and text input. I think this can go side-by-side with the range input so more of the form can be visible on the screen.

![Screenshot_2023-07-26_15-03-45](https://github.com/ccnmtl/econplayground/assets/59292/f17eb247-577e-4241-a23c-d379feaccc3e)
