### PR TITLE
Sentry init: ignore migrate step as well

### DIFF
--- a/econplayground/settings_production.py
+++ b/econplayground/settings_production.py
@@ -18,7 +18,9 @@ try:
 except ImportError:
     pass
 
-if ('collectstatic' not in sys.argv) and hasattr(settings, 'SENTRY_DSN'):
+if ('migrate' not in sys.argv) and \
+   ('collectstatic' not in sys.argv) and \
+   hasattr(settings, 'SENTRY_DSN'):
     sentry_sdk.init(
         dsn=SENTRY_DSN,  # noqa: F405
         integrations=[DjangoIntegration()]

--- a/econplayground/settings_staging.py
+++ b/econplayground/settings_staging.py
@@ -19,7 +19,9 @@ try:
 except ImportError:
     pass
 
-if ('collectstatic' not in sys.argv) and hasattr(settings, 'SENTRY_DSN'):
+if ('migrate' not in sys.argv) and \
+   ('collectstatic' not in sys.argv) and \
+   hasattr(settings, 'SENTRY_DSN'):
     sentry_sdk.init(
         dsn=SENTRY_DSN,  # noqa: F405
         integrations=[DjangoIntegration()],


### PR DESCRIPTION
econplayground-staging ran into this intermittent error again, this time in the migrate step.