### PR TITLE
Remove extraneous slider margin

### DIFF
--- a/media/js/src/form-components/RangeEditor.js
+++ b/media/js/src/form-components/RangeEditor.js
@@ -14,7 +14,7 @@ export default class RangeEditor extends React.Component {
             <React.Fragment>
                 <div className="row">
                     <div className="col">
-                        <div className="form-row slider-wrapper">
+                        <div className="form-row">
                             <label key="dataId" className="w-100" htmlFor={this.props.id}>
                                 {this.props.itemlabel && (
                                     <div style={{display: 'flex'}}>

--- a/media/scss/base/base.scss
+++ b/media/scss/base/base.scss
@@ -23,10 +23,6 @@
     background-color: $background;
 }
 
-.slider-wrapper {
-    margin: 0 0.2rem 1rem 0.2rem;
-}
-
 .card a img {
     border: 1px solid rgba(255, 255, 255, 0);
     border-top-left-radius: 5px;


### PR DESCRIPTION
This is unnecessary as the slider widgets are now in bootstrap's flex grid system.