### PR TITLE
Add basic docker-compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# docker db
+data/db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+FROM python:3
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+WORKDIR /src
+COPY requirements.txt /src/
+RUN pip install --no-deps -r requirements.txt
+COPY . /src/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  web:
+    build: .
+    command: >
+      sh -c "python manage.py migrate --noinput --settings=econplayground.settings_docker &&
+             python manage.py runserver --settings=econplayground.settings_docker 0.0.0.0:8000"
+    volumes:
+      - .:/src
+    ports:
+      - "8000:8000"
+    environment:
+      - POSTGRES_NAME=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    depends_on:
+      - db

--- a/econplayground/settings_docker.py
+++ b/econplayground/settings_docker.py
@@ -1,0 +1,21 @@
+import os
+from econplayground.settings_shared import *  # noqa: F401,F403
+
+
+# docker-compose db container
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ.get('POSTGRES_NAME'),
+        'USER': os.environ.get('POSTGRES_USER'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
+        'HOST': 'db',
+        'PORT': 5432,
+    }
+}
+
+
+try:
+    from econplayground.local_settings import *  # noqa: F401,F403
+except ImportError:
+    pass


### PR DESCRIPTION
This allows econpractice to be run in docker with this command:
```
docker compose up
```

Roughly based on this guide here, and adapted for our pip setup: https://github.com/docker/awesome-compose/tree/master/official-documentation-samples/django/

This is only intended to be used for development purposes and not for production, yet.