### PR TITLE
Make Question/AssessmentRule API

### DIFF
--- a/econplayground/api/permissions.py
+++ b/econplayground/api/permissions.py
@@ -1,0 +1,7 @@
+from rest_framework.permissions import BasePermission
+from econplayground.main.utils import user_is_instructor
+
+
+class IsInstructor(BasePermission):
+    def has_permission(self, request, view):
+        return user_is_instructor(request.user)

--- a/econplayground/api/urls.py
+++ b/econplayground/api/urls.py
@@ -3,8 +3,10 @@ from rest_framework import routers
 from econplayground.api.views import (
     AssessmentViewSet, CohortViewSet,
     GraphViewSet, SubmissionViewSet, TopicViewSet,
-    QuestionViewSet, EvaluationViewSet, UserAssignmentViewSet,
-    QuestionEvaluationViewSet
+    EvaluationViewSet, UserAssignmentViewSet,
+    QuestionEvaluationViewSet,
+
+    QuestionViewSet
 )
 
 
@@ -14,10 +16,12 @@ router.register(r'cohorts', CohortViewSet)
 router.register(r'graphs', GraphViewSet)
 router.register(r'submissions', SubmissionViewSet)
 router.register(r'topics', TopicViewSet)
-router.register(r'questions', QuestionViewSet)
 router.register(r'evaluations', EvaluationViewSet)
 router.register(r'user_assignments', UserAssignmentViewSet)
 router.register(r'question_evaluations', QuestionEvaluationViewSet)
+
+# Used by Rubric react component in the assignment builder
+router.register(r'questions', QuestionViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/econplayground/api/views.py
+++ b/econplayground/api/views.py
@@ -7,15 +7,20 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+
+from econplayground.api.permissions import IsInstructor
 from econplayground.main.models import (
-    Assessment, Cohort, Graph, Submission, Topic, Question, Evaluation,
+    Assessment, Cohort, Graph, Submission, Topic, Evaluation,
     UserAssignment, QuestionEvaluation
 )
+from econplayground.assignment.models import Question
 from econplayground.api.serializers import (
     AssessmentSerializer, CohortSerializer, GraphSerializer,
-    SubmissionSerializer, TopicSerializer, QuestionSerializer,
+    SubmissionSerializer, TopicSerializer,
     EvaluationSerializer, UserAssignmentSerializer,
-    QuestionEvaluationSerializer
+    QuestionEvaluationSerializer,
+
+    QuestionSerializer
 )
 
 
@@ -90,29 +95,6 @@ class CohortViewSet(viewsets.ReadOnlyModelViewSet):
         return Cohort.objects.filter(instructors__in=(user,))
 
 
-class QuestionViewSet(viewsets.ModelViewSet):
-    queryset = Question.objects.all()
-    serializer_class = QuestionSerializer
-
-    def create(self, request):
-        r = super(QuestionViewSet, self).create(request)
-        if r:
-            messages.success(
-                request,
-                'Question "{}" created.'.format(r.data.get('title')))
-
-        return r
-
-    def update(self, request, pk):
-        r = super(QuestionViewSet, self).update(request)
-        if r:
-            messages.success(
-                request,
-                'Question "{}" updated.'.format(r.data.get('title')))
-
-        return r
-
-
 class EvaluationViewSet(viewsets.ModelViewSet):
     queryset = Evaluation.objects.all()
     serializer_class = EvaluationSerializer
@@ -135,3 +117,9 @@ class UserAssignmentViewSet(viewsets.ModelViewSet):
 class QuestionEvaluationViewSet(viewsets.ModelViewSet):
     queryset = QuestionEvaluation.objects.all()
     serializer_class = QuestionEvaluationSerializer
+
+
+class QuestionViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Question.objects.all()
+    serializer_class = QuestionSerializer
+    permission_classes = (IsInstructor,)

--- a/econplayground/assignment/tests/factories.py
+++ b/econplayground/assignment/tests/factories.py
@@ -1,7 +1,9 @@
 import factory
 from factory.django import DjangoModelFactory
 from factory import fuzzy
-from econplayground.assignment.models import Assignment, Question
+from econplayground.assignment.models import (
+    Assignment, Question, AssessmentRule
+)
 from econplayground.main.tests.factories import GraphFactory, InstructorFactory
 
 
@@ -29,6 +31,18 @@ class QuestionFactory(DjangoModelFactory):
     title = fuzzy.FuzzyText()
     prompt = fuzzy.FuzzyText()
     graph = factory.SubFactory(GraphFactory)
+
+
+class AssessmentRuleFactory(DjangoModelFactory):
+    class Meta:
+        model = AssessmentRule
+
+    question = factory.SubFactory(QuestionFactory)
+    assessment_name = fuzzy.FuzzyText()
+    assessment_value = fuzzy.FuzzyText()
+
+    feedback_fulfilled = fuzzy.FuzzyText()
+    feedback_unfulfilled = fuzzy.FuzzyText()
 
 
 class AssignmentMixin(object):

--- a/econplayground/main/utils.py
+++ b/econplayground/main/utils.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import Group
 INSTRUCTOR_LIST = ['tg2451']
 
 
-def user_is_instructor(user):
+def user_is_instructor(user: object) -> bool:
     try:
         # Use INSTRUCTOR_LIST from local_settings if it exists.
         instructor_list = settings.INSTRUCTOR_LIST

--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -27,6 +27,7 @@ PROJECT_APPS = [
 USE_TZ = True
 
 REST_FRAMEWORK = {
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
     ),


### PR DESCRIPTION
Enable read-only view for instructors to load questions. I'm thinking I will use this to load the AssessmentRules in the Rubric react component.

Rule creation, I think, will be handled via standard form POST, but we can make use of this API here for that as well, if necessary.