### PR TITLE
Enable assignment tests

### DIFF
--- a/econplayground/assignment/models.py
+++ b/econplayground/assignment/models.py
@@ -22,6 +22,10 @@ class Question(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    def evaluate_action(self, action_name: str, action_value: str) -> bool:
+        return self.assessmentrule_set.first().evaluate_action(
+            action_name, action_value)
+
 
 class AssessmentRule(models.Model):
     """

--- a/econplayground/assignment/tests/factories.py
+++ b/econplayground/assignment/tests/factories.py
@@ -61,14 +61,18 @@ class AssignmentMixin(object):
         assignment.add_step()
 
         q1 = QuestionFactory()
+        AssessmentRuleFactory(
+            question=q1, assessment_name='', assessment_value='')
         a1.question = q1
         a1.save()
 
         q2 = QuestionFactory()
+        AssessmentRuleFactory(question=q2)
         b1.question = q2
         b1.save()
 
         q3 = QuestionFactory()
+        AssessmentRuleFactory(question=q3)
         c1.question = q3
         c1.save()
 

--- a/econplayground/assignment/tests/test_models.py
+++ b/econplayground/assignment/tests/test_models.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from econplayground.assignment.tests.factories import (
-    AssignmentFactory, QuestionFactory
+    AssignmentFactory, QuestionFactory, AssessmentRuleFactory
 )
 from econplayground.assignment.models import Assignment, Step
 
@@ -210,23 +210,31 @@ class AssignmentTest(TestCase):
         self.c1.add_sibling(instance=self.d1, pos='last-sibling')
 
         # Populate it with questions
-        q1 = QuestionFactory(
+        q1 = QuestionFactory()
+        AssessmentRuleFactory(
+            question=q1,
             assessment_name='line1', assessment_value='up')
         self.a1.question = q1
         self.a1.save()
 
-        q2 = QuestionFactory(
+        q2 = QuestionFactory()
+        AssessmentRuleFactory(
+            question=q2,
             assessment_name='line1_slope', assessment_value='increase')
         self.b1.question = q2
         self.b1.save()
 
-        q3 = QuestionFactory(
+        q3 = QuestionFactory()
+        AssessmentRuleFactory(
+            question=q3,
             assessment_name='line1_label', assessment_value='Demand')
         self.c1.question = q3
         self.c1.save()
 
         # Evaluation of say, the alpha value of a cobb-douglas graph.
-        q4 = QuestionFactory(
+        q4 = QuestionFactory()
+        AssessmentRuleFactory(
+            question=q4,
             assessment_name='alpha', assessment_value='0.6')
         self.d1.question = q4
         self.d1.save()

--- a/econplayground/assignment/tests/test_views.py
+++ b/econplayground/assignment/tests/test_views.py
@@ -53,21 +53,11 @@ class AssignmentManagementViewTest(LoggedInTestInstructorMixin, TestCase):
                     'pk': question_pk,
                 }), {
                     'title': 'New title',
-                    'assessment_name': 'line1',
-                    'assessment_value': 'down',
-                    'feedback_fulfilled': 'Feedback (fulfilled)',
-                    'feedback_unfulfilled': 'Feedback (unfulfilled)',
                 }, follow=True)
 
         self.assertEqual(r.status_code, 200)
         question.refresh_from_db()
         self.assertEqual(question.title, 'New title')
-        self.assertEqual(question.assessment_name, 'line1')
-        self.assertEqual(question.assessment_value, 'down')
-        self.assertEqual(
-            question.feedback_fulfilled, 'Feedback (fulfilled)')
-        self.assertEqual(
-            question.feedback_unfulfilled, 'Feedback (unfulfilled)')
         self.assertContains(r, 'New title')
         self.assertContains(r, 'updated.')
 
@@ -160,10 +150,8 @@ class AssignmentManagementViewTest(LoggedInTestInstructorMixin, TestCase):
                 'assignment_question_create',
                 kwargs={'assignment_pk': self.assignment.pk}), follow=True)
 
-        self.assertContains(
-            r,
-            'Question <strong>{}</strong> created.'.format(
-                Question.objects.last().pk))
+        self.assertContains(r, Question.objects.last().pk)
+        self.assertContains(r, 'created.')
         self.assertEqual(Question.objects.count(), 1)
 
         q = QuestionFactory()
@@ -251,9 +239,10 @@ class AssignmentStudentFlowViewTest(
         assignment = self.setup_sample_assignment()
 
         first_step = assignment.get_root().get_first_child()
-        first_step.question.assessment_name = 'line1'
-        first_step.question.assessment_value = 'up'
-        first_step.question.save()
+        rule = first_step.question.assessmentrule_set.first()
+        rule.assessment_name = 'line1'
+        rule.assessment_value = 'up'
+        rule.save()
 
         r = self.client.post(reverse('step_detail', kwargs={
             'assignment_pk': assignment.pk,

--- a/econplayground/assignment/views.py
+++ b/econplayground/assignment/views.py
@@ -271,18 +271,25 @@ class StepDetailView(LoginRequiredMixin, DetailView):
         action_value = request.POST.get('action_value')
 
         if question:
-            result = question.evaluate_action(action_name, action_value)
+            rule = question.assessmentrule_set.first()
 
-            # Store the result in the user's session.
-            step_name = 'step_{}_{}'.format(step.assignment.pk, step.pk)
-            request.session[step_name] = result
+            if rule:
+                result = rule.evaluate_action(action_name, action_value)
 
-            if result:
-                messages.add_message(
-                    self.request, messages.SUCCESS, 'Correct!')
+                # Store the result in the user's session.
+                step_name = 'step_{}_{}'.format(step.assignment.pk, step.pk)
+                request.session[step_name] = result
+
+                if result:
+                    messages.add_message(
+                        self.request, messages.SUCCESS, 'Correct!')
+                else:
+                    messages.add_message(
+                        self.request, messages.ERROR, 'Incorrect!')
             else:
                 messages.add_message(
-                    self.request, messages.ERROR, 'Incorrect!')
+                    self.request, messages.ERROR,
+                    'Error: no question rubric found')
 
         return HttpResponseRedirect(reverse('step_detail', kwargs={
             'assignment_pk': step.assignment.pk,
@@ -295,8 +302,7 @@ class QuestionCreateView(
         LoginRequiredMixin, CreateView):
     model = Question
     fields = [
-        'title', 'prompt', 'graph', 'assessment_name',
-        'assessment_value',
+        'title', 'prompt', 'graph',
     ]
 
     def test_func(self):


### PR DESCRIPTION
`./manage.py test` wasn't including the assignment tests, because the `__init__.py` file was missing from the directory, so Django's DiscoverRunner couldn't find the tests automatically.

So, I've added that file so the tests are now run, and fixed the tests themselves with some of the recent re-factors I've done.