### PR TITLE
Adjust some rule properties

### DIFF
--- a/econplayground/assignment/views.py
+++ b/econplayground/assignment/views.py
@@ -273,25 +273,18 @@ class StepDetailView(LoginRequiredMixin, DetailView):
         action_value = request.POST.get('action_value')
 
         if question:
-            rule = question.assessmentrule_set.first()
+            result = question.evaluate_action(action_name, action_value)
 
-            if rule:
-                result = rule.evaluate_action(action_name, action_value)
+            # Store the result in the user's session.
+            step_name = 'step_{}_{}'.format(step.assignment.pk, step.pk)
+            request.session[step_name] = result
 
-                # Store the result in the user's session.
-                step_name = 'step_{}_{}'.format(step.assignment.pk, step.pk)
-                request.session[step_name] = result
-
-                if result:
-                    messages.add_message(
-                        self.request, messages.SUCCESS, 'Correct!')
-                else:
-                    messages.add_message(
-                        self.request, messages.ERROR, 'Incorrect!')
+            if result:
+                messages.add_message(
+                    self.request, messages.SUCCESS, 'Correct!')
             else:
                 messages.add_message(
-                    self.request, messages.ERROR,
-                    'Error: no question rubric found')
+                    self.request, messages.ERROR, 'Incorrect!')
 
         return HttpResponseRedirect(reverse('step_detail', kwargs={
             'assignment_pk': step.assignment.pk,

--- a/media/js/src/StepGraphViewer.jsx
+++ b/media/js/src/StepGraphViewer.jsx
@@ -79,7 +79,7 @@ export default class StepGraphViewer extends Component {
         document.addEventListener(`l${line}up`, function(e) {
             let actions = [...me.state.actions, {
                 key: window.crypto.randomUUID(),
-                name: 'line' + line,
+                name: 'line_' + line,
                 value: 'up'
             }];
 
@@ -91,7 +91,7 @@ export default class StepGraphViewer extends Component {
         document.addEventListener(`l${line}down`, function(e) {
             let actions = [...me.state.actions, {
                 key: window.crypto.randomUUID(),
-                name: 'line' + line,
+                name: 'line_' + line,
                 value: 'down'
             }];
 

--- a/media/js/src/rubric/ruleOptions.js
+++ b/media/js/src/rubric/ruleOptions.js
@@ -5,8 +5,8 @@ const lineAssessmentNames = (line) => {
 
     return [
         {
-            'name': `${lineColor} line position`,
-            'value': `line_${line}_offset_y`,
+            'name': `${lineColor} line`,
+            'value': `line_${line}`,
             'values': [
                 {
                     'name': 'Up ↑',
@@ -16,21 +16,7 @@ const lineAssessmentNames = (line) => {
                     'name': 'Down ↓',
                     'value': -1,
                 }
-            ],
-        },
-        {
-            'name': `${lineColor} line slope`,
-            'value': `line_${line}_slope`,
-            'values': [
-                {
-                    'name': 'Increase ↑',
-                    'value': 1,
-                },
-                {
-                    'name': 'Decrease ↓',
-                    'value': -1,
-                }
-            ],
+            ]
         }
     ];
 };


### PR DESCRIPTION
Make the jsxgraph 'actions' format the same as the rule definition, for simpler evaluation.

In other words, the basic rule now looks like:
name: "line_1"
value: "up"

This can be extended to slope like this:
name: "line_1"
value: "increase"

And then for labels:
name: "line_1_label"
value: "Demand"