### PR TITLE
Assignment tests: update assessment format

### DIFF
--- a/econplayground/assignment/tests/test_models.py
+++ b/econplayground/assignment/tests/test_models.py
@@ -213,21 +213,21 @@ class AssignmentTest(TestCase):
         q1 = QuestionFactory()
         AssessmentRuleFactory(
             question=q1,
-            assessment_name='line1', assessment_value='up')
+            assessment_name='line_1', assessment_value='up')
         self.a1.question = q1
         self.a1.save()
 
         q2 = QuestionFactory()
         AssessmentRuleFactory(
             question=q2,
-            assessment_name='line1_slope', assessment_value='increase')
+            assessment_name='line_1', assessment_value='increase')
         self.b1.question = q2
         self.b1.save()
 
         q3 = QuestionFactory()
         AssessmentRuleFactory(
             question=q3,
-            assessment_name='line1_label', assessment_value='Demand')
+            assessment_name='line_1_label', assessment_value='Demand')
         self.c1.question = q3
         self.c1.save()
 
@@ -240,18 +240,18 @@ class AssignmentTest(TestCase):
         self.d1.save()
 
     def test_assignment_flow(self):
-        result1 = self.a1.question.evaluate_action('line2', 'down')
+        result1 = self.a1.question.evaluate_action('line_2', 'down')
         self.assertFalse(result1)
 
-        result2 = self.a1.question.evaluate_action('line1', 'up')
+        result2 = self.a1.question.evaluate_action('line_1', 'up')
         self.assertTrue(result2)
 
         step2 = self.a1.get_next()
-        result3 = step2.question.evaluate_action('line1_slope', 'increase')
+        result3 = step2.question.evaluate_action('line_1', 'increase')
         self.assertTrue(result3)
 
         step3 = step2.get_next()
-        result4 = step3.question.evaluate_action('line1_label', 'demand')
+        result4 = step3.question.evaluate_action('line_1_label', 'demand')
         self.assertTrue(result4)
 
         step4 = step3.get_next()

--- a/econplayground/assignment/tests/test_views.py
+++ b/econplayground/assignment/tests/test_views.py
@@ -229,7 +229,7 @@ class AssignmentStudentFlowViewTest(
             'assignment_pk': assignment.pk,
             'pk': first_step.pk
         }), {
-            'action_name': 'line1',
+            'action_name': 'line_1',
             'action_value': 'down',
         }, follow=True)
 
@@ -240,7 +240,7 @@ class AssignmentStudentFlowViewTest(
             'assignment_pk': assignment.pk,
             'pk': first_step.pk
         }), {
-            'action_name': 'line1',
+            'action_name': 'line_1',
             'action_value': 'up',
         }, follow=True)
 
@@ -252,7 +252,7 @@ class AssignmentStudentFlowViewTest(
 
         first_step = assignment.get_root().get_first_child()
         rule = first_step.question.assessmentrule_set.first()
-        rule.assessment_name = 'line1'
+        rule.assessment_name = 'line_1'
         rule.assessment_value = 'up'
         rule.save()
 
@@ -260,7 +260,7 @@ class AssignmentStudentFlowViewTest(
             'assignment_pk': assignment.pk,
             'pk': first_step.pk
         }), {
-            'action_name': 'line1',
+            'action_name': 'line_1',
             'action_value': 'down',
         }, follow=True)
 
@@ -276,7 +276,7 @@ class AssignmentStudentFlowViewTest(
             'assignment_pk': assignment.pk,
             'pk': first_step.pk
         }), {
-            'action_name': 'line1',
+            'action_name': 'line_1',
             'action_value': 'up',
         }, follow=True)
 


### PR DESCRIPTION
I don't have this documented anywhere yet, but I'm thinking of settling
on something like this for the AssessmentRule format:

**Eval type 1: Line Movement**

name: `line_1`
possible values: up, down, increase, decrease

etc. for lines 2 and 3, as well as other labels on the graph, like X-axis label, intersection point label, etc.

**Eval type 2: Labeling**

name: `line_1_label`
possible values: any text string the instructor expects the label to be

etc. for lines 2 and 3

**Eval type 3: Value comparison**

name: `alpha`
possible values: the desired value of this field. Everything will be
treated as a string at this rubric/rule level, but casted to a Python float at
the evaluation stage, for fuzzy-comparison purposes.

etc. for other possible graph values