### PR TITLE
Adjust landing_url for security purposes

### DIFF
--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -102,7 +102,7 @@ LTI_TOOL_CONFIGURATION = {
     'course_aware': False,
     'frame_width': 1024,
     'frame_height': 1024,
-    'landing_url': '/',
+    'landing_url': '',
     'allow_ta_access': False
 }
 

--- a/econplayground/templates/lti_provider/landing_page.html
+++ b/econplayground/templates/lti_provider/landing_page.html
@@ -14,7 +14,7 @@
                     <p class="lead text-center">EconPractice is an open-source platform for exploring economic principles.</p>
 
                     <p class="lead text-center cover-container">
-                        <a class="btn btn-secondary btn-lg" href="{{landing_url}}" title="Launch EconPractice"
+                        <a class="btn btn-secondary btn-lg" href="/{{landing_url}}" title="Launch EconPractice"
                            target="_blank">Launch</a>
                     </p>
             </div>


### PR DESCRIPTION
This addresses an issue found in CloudDefense: the `/` part of the landing_url should be hard-coded to prevent cross-site scripting.