### PR TITLE
Add value submission basics

### DIFF
--- a/media/js/src/rubric/ruleOptions.js
+++ b/media/js/src/rubric/ruleOptions.js
@@ -77,9 +77,21 @@ const getRuleOptions = () => {
             value: 'parameter',
             names: [
                 {
+                    name: 'A',
+                    value: 'cobb_douglas_a'
+                },
+                {
+                    name: 'K',
+                    value: 'cobb_douglas_k'
+                },
+                {
                     name: 'Alpha (α)',
-                    value: 'alpha'
-                }
+                    value: 'cobb_douglas_alpha'
+                },
+                {
+                    name: 'L',
+                    value: 'cobb_douglas_l'
+                },
             ],
         },
     ];


### PR DESCRIPTION
This required some form adjustments, and additional POST code to account for extra fields within the request. I'm now checking all fields for a correct result, and returning `any(results)`, where `results` is a list of Boolean values.

This code will be cleaned up, I just wanted to get this in with these new tests passing.

Also, I expect we'll do some additional work to actually treat these values as Numbers, possibly with a level of fuzzy comparison where appropriate.