### PR TITLE
Implement dynamic rule names based on graph type

### DIFF
--- a/econplayground/api/serializers.py
+++ b/econplayground/api/serializers.py
@@ -199,6 +199,12 @@ class GraphSerializer(serializers.ModelSerializer):
         return instance
 
 
+class GraphTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Graph
+        fields = ('graph_type',)
+
+
 class EvaluationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Evaluation
@@ -288,9 +294,11 @@ class AssessmentRuleSerializer(serializers.ModelSerializer):
 
 class QuestionSerializer(serializers.ModelSerializer):
     assessmentrule_set = AssessmentRuleSerializer(many=True)
+    graph = GraphTypeSerializer(read_only=True)
 
     class Meta:
         model = Question
         fields = (
             'pk', 'title', 'prompt', 'assessmentrule_set',
+            'graph',
         )

--- a/econplayground/templates/assignment/assignment_questions.html
+++ b/econplayground/templates/assignment/assignment_questions.html
@@ -77,7 +77,9 @@
                                       name="graph"
                                       id="questionGraph-{{question.pk}}">
                                   {% for graph in graphs %}
-                                      <option value="{{graph.pk}}" {% if question.graph.pk == graph.pk %}selected{% endif %}>
+                                      <option data-graphtype="{{graph.graph_type}}"
+                                              value="{{graph.pk}}"
+                                              {% if question.graph.pk == graph.pk %}selected{% endif %}>
                                           {{graph.title}}
                                       </option>
                                   {% endfor %}
@@ -143,6 +145,15 @@ $(document).ready(function() {
     // https://getbootstrap.com/docs/5.3/components/navs-tabs/#javascript-behavior
     $('select.ep-question-select').on('change', function(e) {
         selectQuestion(e.target, Number(e.target.value));
+    });
+
+    $('select[name="graph"]').on('change', function(e) {
+        const selectedOption = e.target.options[e.target.selectedIndex];
+        const graphType = selectedOption.dataset.graphtype;
+        const graphTypeUpdated = new CustomEvent('graphTypeUpdated', {
+            detail: graphType
+        });
+        document.dispatchEvent(graphTypeUpdated);
     });
 });
 </script>

--- a/media/js/src/rubric/AddRule.jsx
+++ b/media/js/src/rubric/AddRule.jsx
@@ -12,7 +12,8 @@ export default function AddRule() {
             feedback_fulfilled: '',
             media_fulfilled: '',
             feedback_unfulfilled: '',
-            media_unfulfilled: ''
+            media_unfulfilled: '',
+            graph_type: null
         });
     }
 

--- a/media/js/src/rubric/RuleList.jsx
+++ b/media/js/src/rubric/RuleList.jsx
@@ -22,7 +22,8 @@ export default function RuleList({ questionId }) {
                     feedback_fulfilled: rule.feedback_fulfilled,
                     media_fulfilled: rule.media_fulfilled,
                     feedback_unfulfilled: rule.feedback_unfulfilled,
-                    media_unfulfilled: rule.media_unfulfilled
+                    media_unfulfilled: rule.media_unfulfilled,
+                    graph_type: d.graph.graph_type
                 });
             });
 
@@ -75,9 +76,17 @@ function getPath(url) {
 
 function Rule({ rule }) {
     const dispatch = useRulesDispatch();
+    const [graphType, setGraphType] = useState(rule.graph_type);
 
     const [fulfilledMedia, setFulfilledMedia] = useState('');
     const [unfulfilledMedia, setUnfulfilledMedia] = useState('');
+
+    useEffect(() => {
+        document.addEventListener('graphTypeUpdated', (e) => {
+            const graphType = window.parseInt(e.detail);
+            setGraphType(graphType);
+        });
+    });
 
     function onClickRemoveRule() {
         dispatch({
@@ -102,9 +111,8 @@ function Rule({ rule }) {
             });
     }
 
-    const names = getRuleOptions().map((x) => {
-        return x.names;
-    }).flat();
+    // Get graph type
+    const names = getRuleOptions(graphType);
 
     const renderedNames = names.map((x) => {
         return (

--- a/media/js/src/rubric/RulesContext.jsx
+++ b/media/js/src/rubric/RulesContext.jsx
@@ -44,7 +44,8 @@ function rulesReducer(rules, action) {
                 feedback_fulfilled: action.feedback_fulfilled,
                 media_fulfilled: action.media_fulfilled,
                 feedback_unfulfilled: action.feedback_unfulfilled,
-                media_unfulfilled: action.media_unfulfilled
+                media_unfulfilled: action.media_unfulfilled,
+                graph_type: action.graph_type
             }];
         }
         case 'changed': {

--- a/media/js/src/rubric/ruleOptions.js
+++ b/media/js/src/rubric/ruleOptions.js
@@ -1,100 +1,105 @@
-const LINE_COLORS = ['Orange', 'Blue', 'Red'];
+// Graph type 0
+const linearDemandOptions = [
+    {
+        name: 'Orange line',
+        value: 'line1',
+    },
+    {
+        name: 'Blue line',
+        value: 'line2',
+    },
+    {
+        name: 'Orange line label',
+        value: 'line_1_label'
+    },
+    {
+        name: 'Blue line label',
+        value: 'line_2_label'
+    },
+    {
+        name: 'X-axis label',
+        value: 'x_axis_label'
+    },
+    {
+        name: 'Y-axis label',
+        value: 'y_axis_label'
+    },
+    {
+        name: 'Intersection point label',
+        value: 'intersection_label'
+    },
+    {
+        name: 'Intersection\'s horizontal line label',
+        value: 'intersection_horiz_line_label'
+    },
+    {
+        name: 'Intersection\'s vertical line label',
+        value: 'intersection_vert_line_label'
+    },
+    {
+        name: 'Orange line slope',
+        value: 'line_1_slope'
+    },
+    {
+        name: 'Blue line slope',
+        value: 'line_2_slope'
+    }
+];
 
-const lineAssessmentNames = (line) => {
-    const lineColor = LINE_COLORS[line - 1];
+// Graph type 3
+const cobbDouglasOptions = [
+    {
+        name: 'Intersection point label',
+        value: 'intersection_label'
+    },
+    {
+        name: 'Y label',
+        value: 'cobb_douglas_y_name'
+    },
+    {
+        name: 'A label',
+        value: 'cobb_douglas_a_name'
+    },
+    {
+        name: 'K label',
+        value: 'cobb_douglas_k_name'
+    },
+    {
+        name: 'L label',
+        value: 'cobb_douglas_l_name'
+    },
+    {
+        name: 'A',
+        value: 'cobb_douglas_a'
+    },
+    {
+        name: 'K',
+        value: 'cobb_douglas_k'
+    },
+    {
+        name: 'Alpha (α)',
+        value: 'cobb_douglas_alpha'
+    },
+    {
+        name: 'L',
+        value: 'cobb_douglas_l'
+    }
+];
 
-    return [
-        {
-            'name': `${lineColor} line`,
-            'value': `line_${line}`,
-            'values': [
-                {
-                    'name': 'Up ↑',
-                    'value': 1,
-                },
-                {
-                    'name': 'Down ↓',
-                    'value': -1,
-                }
-            ]
-        }
-    ];
-};
-
-const getRuleOptions = () => {
-    return [
-        {
-            name: 'Orange line',
-            value: 'line1',
-            names: lineAssessmentNames(1),
-        },
-        {
-            name: 'Blue line',
-            value: 'line2',
-            names: lineAssessmentNames(2),
-        },
-        {
-            name: 'Red line',
-            value: 'line3',
-            names: lineAssessmentNames(3),
-        },
-        {
-            name: 'Label',
-            value: 'label',
-            names: [
-                {
-                    name: 'Orange line label',
-                    value: 'line_1_label'
-                },
-                {
-                    name: 'Blue line label',
-                    value: 'line_2_label'
-                },
-                {
-                    name: 'X-axis label',
-                    value: 'x_axis_label'
-                },
-                {
-                    name: 'Y-axis label',
-                    value: 'y_axis_label'
-                },
-                {
-                    name: 'Intersection point label',
-                    value: 'intersection_label'
-                },
-                {
-                    name: 'Intersection\'s horizontal line label',
-                    value: 'intersection_horiz_line_label'
-                },
-                {
-                    name: 'Intersection\'s vertical line label',
-                    value: 'intersection_vert_line_label'
-                }
-            ],
-        },
-        {
-            name: 'Parameter',
-            value: 'parameter',
-            names: [
-                {
-                    name: 'A',
-                    value: 'cobb_douglas_a'
-                },
-                {
-                    name: 'K',
-                    value: 'cobb_douglas_k'
-                },
-                {
-                    name: 'Alpha (α)',
-                    value: 'cobb_douglas_alpha'
-                },
-                {
-                    name: 'L',
-                    value: 'cobb_douglas_l'
-                },
-            ],
-        },
-    ];
+/**
+ * getRuleOptions
+ *
+ * Get the appropriate rule options based on graph type.
+ */
+const getRuleOptions = (graphType) => {
+    switch (graphType) {
+        case 0:
+            return linearDemandOptions;
+        case 3:
+            return cobbDouglasOptions;
+        default:
+            return [];
+    }
 };
 
 export { getRuleOptions };


### PR DESCRIPTION
The next step here is to flesh this out to be compatible with all graph types. Currently I have the rules in place for Linear Demand and Cobb Douglas.

The main change here is the custom event mechanism which updates the assessment rule names in the React component.