### PR TITLE
Switch to postgres for unit testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,8 +7,21 @@ jobs:
     strategy:
       matrix:
           python-version: ['3.8', '3.11']
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -25,7 +38,7 @@ jobs:
           node-version: [18.x]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/econplayground/main/migrations/0052_create_general_topic.py
+++ b/econplayground/main/migrations/0052_create_general_topic.py
@@ -7,7 +7,9 @@ def create_general_topic(apps, schema_editor):
 
     Graph.objects.all().update(topic=None)
     Topic.objects.all().delete()
-    t = Topic.objects.create(name='General', pk=1, order=1)
+
+    t, _ = Topic.objects.get_or_create(name='General', order=1)
+
     Graph.objects.all().update(topic=t)
 
 

--- a/econplayground/main/tests/test_views.py
+++ b/econplayground/main/tests/test_views.py
@@ -582,7 +582,7 @@ class CohortDetailInstructorViewTest(LoggedInTestInstructorMixin, TestCase):
         self.assertNotContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], True)
-        self.assertEqual(r.context['active_topic'], '')
+        self.assertEqual(r.context['active_topic'], None)
         self.assertEqual(r.context['topic_list'].count(), 5)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')
@@ -612,7 +612,7 @@ class CohortDetailInstructorViewTest(LoggedInTestInstructorMixin, TestCase):
         self.assertContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], False)
-        self.assertEqual(r.context['active_topic'], '')
+        self.assertEqual(r.context['active_topic'], None)
         self.assertEqual(r.context['topic_list'].count(), 5)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')
@@ -639,7 +639,7 @@ class CohortDetailInstructorViewTest(LoggedInTestInstructorMixin, TestCase):
         self.assertNotContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], False)
-        self.assertEqual(r.context['active_topic'], 3)
+        self.assertEqual(r.context['active_topic'], self.t1.pk)
         self.assertEqual(r.context['topic_list'].count(), 5)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')
@@ -665,7 +665,7 @@ class CohortDetailInstructorViewTest(LoggedInTestInstructorMixin, TestCase):
         self.assertContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], False)
-        self.assertEqual(r.context['active_topic'], 4)
+        self.assertEqual(r.context['active_topic'], self.t2.pk)
         self.assertEqual(r.context['topic_list'].count(), 5)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')
@@ -691,7 +691,7 @@ class CohortDetailInstructorViewTest(LoggedInTestInstructorMixin, TestCase):
         self.assertNotContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], False)
-        self.assertEqual(r.context['active_topic'], 5)
+        self.assertEqual(r.context['active_topic'], self.t3.pk)
         self.assertEqual(r.context['topic_list'].count(), 5)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')
@@ -742,7 +742,7 @@ class CohortDetailStudentViewTest(LoggedInTestStudentMixin, TestCase):
         self.assertNotContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], True)
-        self.assertEqual(r.context['active_topic'], '')
+        self.assertEqual(r.context['active_topic'], None)
         self.assertEqual(r.context['topic_list'].count(), 2)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')
@@ -763,7 +763,7 @@ class CohortDetailStudentViewTest(LoggedInTestStudentMixin, TestCase):
         self.assertNotContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], False)
-        self.assertEqual(r.context['active_topic'], '')
+        self.assertEqual(r.context['active_topic'], None)
         self.assertEqual(r.context['topic_list'].count(), 2)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')
@@ -786,7 +786,7 @@ class CohortDetailStudentViewTest(LoggedInTestStudentMixin, TestCase):
         self.assertNotContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], False)
-        self.assertEqual(r.context['active_topic'], 3)
+        self.assertEqual(r.context['active_topic'], self.t1.pk)
         self.assertEqual(r.context['topic_list'].count(), 2)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')
@@ -809,7 +809,7 @@ class CohortDetailStudentViewTest(LoggedInTestStudentMixin, TestCase):
         self.assertNotContains(r, 'Draft graph')
         # Context Data
         self.assertEqual(r.context['featured'], False)
-        self.assertEqual(r.context['active_topic'], 4)
+        self.assertEqual(r.context['active_topic'], self.t2.pk)
         self.assertEqual(r.context['topic_list'].count(), 2)
         self.assertContains(r, 'Topic A')
         self.assertContains(r, 'Topic B')

--- a/econplayground/main/views.py
+++ b/econplayground/main/views.py
@@ -319,12 +319,12 @@ class CohortDetailView(CohortPasswordMixin, DetailView):
         # the query string.
         params = self.request.GET
         context['featured'] = False
-        context['active_topic'] = ''
+        context['active_topic'] = None
 
         if len(params) == 0:
             context['featured'] = True
         elif 'topic' in params:
-            tid = params.get('topic', '')
+            tid = params.get('topic', None)
             try:
                 context['active_topic'] = int(tid)
             except ValueError:

--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -1,4 +1,5 @@
 # Django settings for econplayground project.
+import sys
 import os.path
 from ctlsettings.shared import common
 
@@ -10,6 +11,19 @@ locals().update(common(project=project, base=base))
 PROJECT_APPS = [
     'econplayground.main',
 ]
+
+if 'test' in sys.argv or 'jenkins' in sys.argv:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': project,
+            'HOST': 'localhost',
+            'PORT': 5432,
+            'USER': 'postgres',
+            'PASSWORD': 'postgres',
+            'ATOMIC_REQUESTS': True,
+        }
+    }
 
 USE_TZ = True
 


### PR DESCRIPTION
This required removing some hard-coded primary keys in the tests in a few places, which is bad practice.