### PR TITLE
Adjust postgres test authentication

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Flake8
         run: make flake8
       - name: Test
-        run: make test
+        run: GITHUB=true make test
   js:
     name: JS tests
     runs-on: ubuntu-20.04

--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -1,5 +1,6 @@
 # Django settings for econplayground project.
 import sys
+import os
 import os.path
 from ctlsettings.shared import common
 
@@ -13,14 +14,18 @@ PROJECT_APPS = [
 ]
 
 if 'test' in sys.argv or 'jenkins' in sys.argv:
+    # GitHub Actions needs a slightly different postgres config
+    # than local dev / jenkins.
+    GITHUB = os.environ.get('GITHUB')
+
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': project,
-            'HOST': 'localhost',
+            'HOST': 'localhost' if GITHUB else '',
             'PORT': 5432,
-            'USER': 'postgres',
-            'PASSWORD': 'postgres',
+            'USER': 'postgres' if GITHUB else '',
+            'PASSWORD': 'postgres' if GITHUB else '',
             'ATOMIC_REQUESTS': True,
         }
     }


### PR DESCRIPTION
dev + jenkins needs empty host name to connect to postgres via
domain sockets rather than TCP, which is used in github actions.