### PR TITLE
Add logic for inferring "Last step" of an assignment

### DIFF
--- a/econplayground/assignment/models.py
+++ b/econplayground/assignment/models.py
@@ -181,6 +181,12 @@ class Step(MP_Node):
         'self', on_delete=models.SET_NULL,
         blank=True, null=True)
 
+    @property
+    def is_last_step(self) -> bool:
+        return self.next_step is None and \
+            self.get_next() is None and \
+            self.get_next_intervention() is None
+
     def get_prev(self) -> Self:
         """Return the previous child, or the prev sibling, or None."""
 

--- a/econplayground/assignment/tests/test_models.py
+++ b/econplayground/assignment/tests/test_models.py
@@ -84,6 +84,14 @@ class AssignmentTreeTest(TestCase):
     def test_get_root(self):
         self.assertIsInstance(self.x.get_root(), Step)
 
+    def test_last_step(self):
+        self.make_test_assignment()
+        self.assertFalse(self.a1.is_last_step)
+        self.assertFalse(self.b1.is_last_step)
+        self.assertFalse(self.c1.is_last_step)
+        self.assertFalse(self.d1.is_last_step)
+        self.assertTrue(self.e1.is_last_step)
+
     def test_make_steps(self):
         root = self.x.get_root()
         step = Step(assignment=root.assignment)

--- a/econplayground/assignment/views.py
+++ b/econplayground/assignment/views.py
@@ -100,10 +100,16 @@ class AssignmentDetailView(
         questions = Question.objects.order_by('created_at')
         steps = Step.objects.filter(assignment=self.object)
 
+        last_step_id = None
+        for step in steps:
+            if step.is_last_step:
+                last_step_id = step.pk
+
         ctx.update({
             'tree': root.get('children'),
             'steps': steps,
             'questions': questions,
+            'last_step_id': last_step_id,
         })
         return ctx
 

--- a/econplayground/templates/assignment/assignment_step_layout.html
+++ b/econplayground/templates/assignment/assignment_step_layout.html
@@ -22,6 +22,9 @@
             <a href="{% url 'step_detail' object.pk step.id %}">
                 Step {{step.id}}
             </a>
+            {% if step.id == last_step_id %}
+                (End)
+            {% endif %}
             <form name="remove_step" method="post"
                   class="float-end mb-1"
                   action="{% url 'tree_edit' object.pk %}">
@@ -70,6 +73,10 @@
                             <a href="{% url 'step_detail' object.pk substep.id %}">
                                 Step {{substep.id}}
                             </a>
+
+                            {% if substep.id == last_step_id %}
+                                (End)
+                            {% endif %}
 
                             <form name="remove_step" method="post"
                                   class="float-end mb-1"


### PR DESCRIPTION
Currently this is configured as the final sibling/child of the tree.