### PR TITLE
Step navigation is adjusted to stay within the assignment

### DIFF
--- a/econplayground/assignment/models.py
+++ b/econplayground/assignment/models.py
@@ -184,11 +184,13 @@ class Step(MP_Node):
     @property
     def is_last_step(self) -> bool:
         return self.next_step is None and \
-            self.get_next() is None and \
-            self.get_next_intervention() is None
+            self.get_next_sibling() is None and \
+            self.get_next() is None
 
     def get_prev(self) -> Self:
         """Return the previous child, or the prev sibling, or None."""
+        if self.is_root_node:
+            return None
 
         node = self.get_prev_sibling()
         if node:
@@ -197,7 +199,11 @@ class Step(MP_Node):
                 return child
 
         if not node:
-            return self.get_parent()
+            parent = self.get_parent()
+            if parent and not parent.is_root_node:
+                return parent
+            else:
+                return None
 
         return node
 
@@ -207,12 +213,13 @@ class Step(MP_Node):
         This is probably the result of a correct answer on the student
         side.
         """
+
         node = self.get_next_sibling()
         if node:
             return node
 
         parent = self.get_parent()
-        if parent:
+        if parent and not parent.is_root_node:
             node = parent.get_next_sibling()
 
         if node:

--- a/econplayground/assignment/tests/test_models.py
+++ b/econplayground/assignment/tests/test_models.py
@@ -15,6 +15,7 @@ class AssignmentTreeTest(TestCase):
     """Structure tests for unpopulated assignments"""
     def setUp(self):
         self.x = AssignmentFactory()
+        self.x2 = AssignmentFactory()
 
     def make_test_assignment(self):
         """
@@ -74,6 +75,7 @@ class AssignmentTreeTest(TestCase):
 
         self.e1 = Step(assignment=self.root.assignment)
         self.d1.add_sibling(instance=self.e1, pos='last-sibling')
+        self.root2 = self.x2.get_root()
 
         return self.a1
 
@@ -195,6 +197,11 @@ class AssignmentTreeTest(TestCase):
         step_7 = step_6.get_next_intervention()
         self.assertEqual(step_7, self.d1)
         self.assertEqual(step_7.get_depth(), 2)
+
+    def test_assignment_delete_cascade(self):
+        pk = self.x.pk
+        self.x.delete()
+        self.assertFalse(Step.objects.filter(assignment=pk).exists())
 
 
 class QuestionTest(TestCase):


### PR DESCRIPTION
This is all I can do for now. More changes will have to be made once the score path is implemented.

~~I removed next_step from the model because it's not being used and it's already implied by the path property of MP_Node~~
![Screenshot 2023-11-20 at 11 49 18 AM](https://github.com/ccnmtl/econplayground/assets/107073665/49212071-4035-47db-a459-bbea157399a9)

Added a test to check for Assignment delete cascade