### PR TITLE
Remove ipaddress library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ logilab-common==2.0.0
 astroid==3.0.2
 pylint==3.0.3
 six==1.16.0
-ipaddress==1.0.23  # faker
 faker==22.4.0  # factory_boy
 factory_boy==3.3.0
 ldap3==2.9.1


### PR DESCRIPTION
This library is not necessary anymore, as it is a backport of a built-in python module which is included in python since version 3.3.

https://pypi.org/project/ipaddress/

Also, this library is causing a security alert.