### PR TITLE
Add CSRF_TRUSTED_ORIGINS config

### DIFF
--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -109,6 +109,10 @@ AUTHENTICATION_BACKENDS = [
     'lti_provider.auth.LTIBackend',
 ]
 
+CSRF_TRUSTED_ORIGINS = [
+    'https://*.ctl.columbia.edu',
+]
+
 LTI_TOOL_CONFIGURATION = {
     'title': 'EconPractice',
     'description': 'Interactive economics graphs',


### PR DESCRIPTION
I'm getting a 403 CSRF failed error in the admin page for econplayground when making a POST. It looks like we may require a new setting, as of django 4.0, to allow for CSRF forms to work.

If this fixes the problem, I will add it to ctlsettings.

* https://forum.djangoproject.com/t/csrf-verification-error-for-django-admin-login/11785/7
* https://docs.djangoproject.com/en/4.2/ref/settings/#csrf-trusted-origins