### PR TITLE
Add updateGraph as required prop of EditableControl

### DIFF
--- a/media/js/src/form-components/EditableControl.js
+++ b/media/js/src/form-components/EditableControl.js
@@ -34,6 +34,11 @@ export default class EditableControl extends React.Component {
 EditableControl.propTypes = {
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
+
+    // updateGraph is required by handleFormUpdate, bound to this with
+    // onChange.
+    updateGraph: PropTypes.func.isRequired,
+
     isInstructor: PropTypes.bool.isRequired,
     value: PropTypes.string,
     valueEditable: PropTypes.bool.isRequired,


### PR DESCRIPTION
This argument seems to be required for the functionality of this control, and is used at the end of the handleFormUpdate function.