### PR TITLE
Migrate to better-react-mathjax

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,8 +8,8 @@ const config = {
     },
     transformIgnorePatterns: [],
     testPathIgnorePatterns: [
-        // Temporary workaround for mathjax3-react issue:
-        // https://github.com/asnunes/mathjax3-react/issues/30
+        // Temporary workaround for better-react-mathjax issue:
+        // https://github.com/fast-reflexes/better-react-mathjax/issues/62
         "media/js/src/form-components/RangeEditor.test.js",
         "media/js/src/JXGBoard.test.js",
         "media/js/src/GraphEditor.test.js",

--- a/media/js/src/Editor.test.js
+++ b/media/js/src/Editor.test.js
@@ -3,38 +3,51 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import ReactTestUtils from 'react-dom/test-utils';
+import { MathJaxContext } from 'better-react-mathjax';
 import Editor from './Editor.jsx';
 import { exportGraph } from './GraphMapping.js';
 
 it('renders without crashing', () => {
-    TestRenderer.create(<Editor />);
+    TestRenderer.create(
+        <MathJaxContext>
+            <Editor />
+        </MathJaxContext>
+    );
 });
 
 it('renders with children in the expected visibility state', () => {
-    TestRenderer.create(<Editor />, function() {
-        expect(this.gp.current.props.showing).toBe(true);
-        expect(this.ge.current.props.showing).toBe(false);
+    TestRenderer.create(
+        <MathJaxContext>
+            <Editor />
+        </MathJaxContext>,
+        function() {
+            expect(this.gp.current.props.showing).toBe(true);
+            expect(this.ge.current.props.showing).toBe(false);
 
-        expect(ReactTestUtils.isCompositeComponent(this.gp.current)).toBe(true);
-        expect(ReactTestUtils.isCompositeComponent(this.ge.current)).toBe(true);
+            expect(ReactTestUtils.isCompositeComponent(this.gp.current)).toBe(true);
+            expect(ReactTestUtils.isCompositeComponent(this.ge.current)).toBe(true);
 
-        expect(this.state.step).toBe(0);
-        expect(this.state.gType).toBe(null);
-        ReactTestUtils.Simulate.click(this.gp.current.b1);
-        // expect(this.state.step).toBe(1);
-    });
+            expect(this.state.step).toBe(0);
+            expect(this.state.gType).toBe(null);
+            ReactTestUtils.Simulate.click(this.gp.current.b1);
+            // expect(this.state.step).toBe(1);
+        });
 });
 
 it('exports its graph state', () => {
-    TestRenderer.create(<Editor />, function() {
-        let o = exportGraph(this.state);
-        expect(o.graph_type).toBe(null);
-        expect(o.show_intersection).toBe(true);
-        expect(o.line_1_slope).toBe(1);
-        expect(o.line_2_slope).toBe(-1);
-        expect(o.line_1_label).toBe('');
-        expect(o.line_2_label).toBe('');
-        expect(o.y_axis_label).toBe('');
-        expect(o.x_axis_label).toBe('');
-    });
+    TestRenderer.create(
+        <MathJaxContext>
+            <Editor />
+        </MathJaxContext>,
+        function() {
+            let o = exportGraph(this.state);
+            expect(o.graph_type).toBe(null);
+            expect(o.show_intersection).toBe(true);
+            expect(o.line_1_slope).toBe(1);
+            expect(o.line_2_slope).toBe(-1);
+            expect(o.line_1_label).toBe('');
+            expect(o.line_2_label).toBe('');
+            expect(o.y_axis_label).toBe('');
+            expect(o.x_axis_label).toBe('');
+        });
 });

--- a/media/js/src/JXGBoard.jsx
+++ b/media/js/src/JXGBoard.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJaxProvider, MathJaxFormula } from 'mathjax3-react';
+import { MathJax } from 'better-react-mathjax';
 import JXG from 'jsxgraph';
 import {graphTypes} from './graphs/graphTypes.js';
 import {mkNonLinearDemandSupply} from './graphs/NonLinearDemandSupplyGraph.js';
@@ -589,14 +589,14 @@ export default class JXGBoard extends React.Component {
                 const func1 = String.raw`MP_${this.props.gNName} = (1 - \alpha)${this.props.gCobbDouglasAName}${this.props.gCobbDouglasKName}^\alpha ${this.props.gNName}^{-\alpha}`;
                 const func2 = String.raw`MP_${this.props.gCobbDouglasKName} = \alpha ${this.props.gCobbDouglasAName}${this.props.gCobbDouglasKName}^{\alpha - 1} ${this.props.gNName}^{1 - \alpha}`;
                 math1 = (
-                    <MathJaxProvider>
-                        <MathJaxFormula formula={'$$' + func1 + '$$'} />
-                    </MathJaxProvider>
+                    <MathJax>
+                        {'$$' + func1 + '$$'}
+                    </MathJax>
                 );
                 math2 = (
-                    <MathJaxProvider>
-                        <MathJaxFormula formula={'$$' + func2 + '$$'} />
-                    </MathJaxProvider>
+                    <MathJax>
+                        {'$$' + func2 + '$$'}
+                    </MathJax>
                 );
             }
             figure2 = false;

--- a/media/js/src/JXGBoard.test.js
+++ b/media/js/src/JXGBoard.test.js
@@ -2,12 +2,16 @@
 
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
+import { MathJaxContext } from 'better-react-mathjax';
 import JXGBoard from './JXGBoard.jsx';
 
 it('renders without crashing', () => {
     TestRenderer.create(
-        <JXGBoard
-            id={'id-test'}
-            gType={0}
-            gShowIntersection={true} />);
+        <MathJaxContext>
+            <JXGBoard
+                id={'id-test'}
+                gType={0}
+                gShowIntersection={true} />
+        </MathJaxContext>
+    );
 });

--- a/media/js/src/editor-main.js
+++ b/media/js/src/editor-main.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { MathJaxContext } from 'better-react-mathjax';
 import Editor from './Editor.jsx';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
-root.render(<Editor />);
+root.render(
+    <MathJaxContext>
+        <Editor />
+    </MathJaxContext>
+);

--- a/media/js/src/editors/CobbDouglasEditor.jsx
+++ b/media/js/src/editors/CobbDouglasEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJaxProvider, MathJaxFormula } from 'mathjax3-react';
+import { MathJax } from 'better-react-mathjax';
 import RangeEditor from '../form-components/RangeEditor.js';
 import EditableControl from '../form-components/EditableControl.jsx';
 import { handleFormUpdate } from '../utils.js';
@@ -37,9 +37,9 @@ export default class CobbDouglasEditor extends React.Component {
                         </div>
                     )}
                     <div className="col">
-                        <MathJaxProvider>
-                            <MathJaxFormula formula={'$$' + tex + '$$'} />
-                        </MathJaxProvider>
+                        <MathJax>
+                            {'$$' + tex + '$$'}
+                        </MathJax>
                     </div>
                 </div>
                 <hr />

--- a/media/js/src/editors/CobbDouglasNLDSEditor.jsx
+++ b/media/js/src/editors/CobbDouglasNLDSEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJaxProvider, MathJaxFormula } from 'mathjax3-react';
+import { MathJax } from 'better-react-mathjax';
 import RangeEditor from '../form-components/RangeEditor.js';
 import EditableControl from '../form-components/EditableControl.jsx';
 import { handleFormUpdate } from '../utils.js';
@@ -39,9 +39,9 @@ export default class CobbDouglasNLDSEditor extends React.Component {
                         </div>
                     )}
                     <div className="col">
-                        <MathJaxProvider>
-                            <MathJaxFormula formula={'$$' + tex + '$$'} />
-                        </MathJaxProvider>
+                        <MathJax>
+                            {'$$' + tex + '$$'}
+                        </MathJax>
                     </div>
                 </div>
 
@@ -63,9 +63,9 @@ export default class CobbDouglasNLDSEditor extends React.Component {
                                     value={0}
                                     checked={this.props.gFunctionChoice === 0} />
                                 <label className="form-check-label" htmlFor="gFunctionChoice1">
-                                    <MathJaxProvider>
-                                        <MathJaxFormula formula={'$$' + func1 + '$$'} />
-                                    </MathJaxProvider>
+                                    <MathJax>
+                                        {'$$' + func1 + '$$'}
+                                    </MathJax>
                                 </label>
                             </div>
                         </div>
@@ -81,9 +81,9 @@ export default class CobbDouglasNLDSEditor extends React.Component {
                                     value={1}
                                     checked={this.props.gFunctionChoice === 1} />
                                 <label className="form-check-label" htmlFor="gFunctionChoice2">
-                                    <MathJaxProvider>
-                                        <MathJaxFormula formula={'$$' + func2 + '$$'} />
-                                    </MathJaxProvider>
+                                    <MathJax>
+                                        {'$$' + func2 + '$$'}
+                                    </MathJax>
                                 </label>
                             </div>
                         </div>

--- a/media/js/src/editors/ConsumptionLeisureEditor.jsx
+++ b/media/js/src/editors/ConsumptionLeisureEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJaxProvider, MathJaxFormula } from 'mathjax3-react';
+import { MathJax } from 'better-react-mathjax';
 import RangeEditor from '../form-components/RangeEditor.js';
 import EditableControl from '../form-components/EditableControl.jsx';
 import { handleFormUpdate } from '../utils.js';
@@ -21,9 +21,9 @@ export default class ConsumptionLeisureEditor extends React.Component {
                         <h2>Function</h2>
                         <div className="row">
                             <div className="col-auto">
-                                <MathJaxProvider>
-                                    <MathJaxFormula formula={'$$' + tex + '$$'} />
-                                </MathJaxProvider>
+                                <MathJax>
+                                    {'$$' + tex + '$$'}
+                                </MathJax>
                             </div>
                         </div>
                         <hr />

--- a/media/js/src/editors/ConsumptionSavingEditor.jsx
+++ b/media/js/src/editors/ConsumptionSavingEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJaxProvider, MathJaxFormula } from 'mathjax3-react';
+import { MathJax } from 'better-react-mathjax';
 import RangeEditor from '../form-components/RangeEditor.js';
 import EditableControl from '../form-components/EditableControl.jsx';
 import { handleFormUpdate } from '../utils.js';
@@ -15,9 +15,9 @@ export default class ConsumptionSavingEditor extends React.Component {
                     <React.Fragment>
                         <h2>Function</h2>
                         <div className="row ml-2 mb-2">
-                            <MathJaxProvider>
-                                <MathJaxFormula formula={'$$' + tex + '$$'} />
-                            </MathJaxProvider>
+                            <MathJax>
+                                {'$$' + tex + '$$'}
+                            </MathJax>
                         </div>
                     </React.Fragment>
                 }

--- a/media/js/src/editors/NonLinearDemandSupplyEditor.jsx
+++ b/media/js/src/editors/NonLinearDemandSupplyEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJaxProvider, MathJaxFormula } from 'mathjax3-react';
+import { MathJax } from 'better-react-mathjax';
 import RangeEditor from '../form-components/RangeEditor.js';
 import EditableControl from '../form-components/EditableControl.jsx';
 import AreaConfiguration from './AreaConfiguration.jsx';
@@ -26,9 +26,9 @@ export default class NonLinearDemandSupplyEditor extends React.Component {
                                 checked={this.props.gFunctionChoice === 0} />
 
                             <label className="form-check-label" htmlFor="gFunctionChoice1">
-                                <MathJaxProvider>
-                                    <MathJaxFormula formula={'$$' + func1 + '$$'} />
-                                </MathJaxProvider>
+                                <MathJax>
+                                    {'$$' + func1 + '$$'}
+                                </MathJax>
                             </label>
                         </div>
                         <div className="form-check">
@@ -40,9 +40,9 @@ export default class NonLinearDemandSupplyEditor extends React.Component {
                                 value={1}
                                 checked={this.props.gFunctionChoice === 1} />
                             <label className="form-check-label" htmlFor="gFunctionChoice2">
-                                <MathJaxProvider>
-                                    <MathJaxFormula formula={'$$' + func2 + '$$'} />
-                                </MathJaxProvider>
+                                <MathJax>
+                                    {'$$' + func2 + '$$'}
+                                </MathJax>
                             </label>
                         </div>
                         <hr />

--- a/media/js/src/editors/TemplateGraphEditor.jsx
+++ b/media/js/src/editors/TemplateGraphEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJaxProvider, MathJaxFormula } from 'mathjax3-react';
+import { MathJax } from 'better-react-mathjax';
 import { create, all } from 'mathjs';
 
 import {handleFormUpdate} from '../utils.js';
@@ -50,9 +50,9 @@ export default class TemplateGraphEditor extends React.Component {
                         <label
                             className="form-check-label me-2 flex-shrink-1 d-flex align-self-center"
                             htmlFor={`g${name}`}>
-                            <MathJaxProvider>
-                                <MathJaxFormula formula="$$y = $$" />
-                            </MathJaxProvider>
+                            <MathJax>
+                                {'$$y = $$'}
+                            </MathJax>
                         </label>
                         <input
                             type="text"

--- a/media/js/src/form-components/RangeEditor.js
+++ b/media/js/src/form-components/RangeEditor.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJaxProvider, MathJaxFormula } from 'mathjax3-react';
+import { MathJax } from 'better-react-mathjax';
 import { btnStep } from '../utils.js';
 
 /**
@@ -18,9 +18,9 @@ export default class RangeEditor extends React.Component {
                             <label key="dataId" className="w-100" htmlFor={this.props.id}>
                                 {this.props.itemlabel && (
                                     <div style={{display: 'flex'}}>
-                                        <MathJaxProvider>
-                                            <MathJaxFormula formula={'$$' + this.props.itemlabel + '$$'} />
-                                        </MathJaxProvider>
+                                        <MathJax>
+                                            {'$$' + this.props.itemlabel + '$$'}
+                                        </MathJax>
                                     </div>
                                 )}
 

--- a/media/js/src/form-components/RangeEditor.test.js
+++ b/media/js/src/form-components/RangeEditor.test.js
@@ -2,31 +2,36 @@
 
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
+import { MathJaxContext } from 'better-react-mathjax';
 import RangeEditor from './RangeEditor.js';
 
 it('renders without crashing', () => {
     const el = TestRenderer.create(
-        <RangeEditor
-            dataId="gCobbDouglasA"
-            value={0}
-            handler={function() {}}
-            min={0} />
+        <MathJaxContext>
+            <RangeEditor
+                dataId="gCobbDouglasA"
+                value={0}
+                handler={function() {}}
+                min={0} />
+        </MathJaxContext>
     );
     if (!el){ console.error('el does not exist'); }
 });
 
 it('Displays override radio button when configured', () => {
     const el = TestRenderer.create(
-        <RangeEditor
-            dataId="gCobbDouglasA"
-            value={0}
-            handler={function() {}}
-            min={0}
-            max={5}
-            showOverrideButton={true}
-            overrideLabel={'override'}
-            overrideValue={10000}
-        />
+        <MathJaxContext>
+            <RangeEditor
+                dataId="gCobbDouglasA"
+                value={0}
+                handler={function() {}}
+                min={0}
+                max={5}
+                showOverrideButton={true}
+                overrideLabel={'override'}
+                overrideValue={10000}
+            />
+        </MathJaxContext>
     ).root;
     const button = el.findByProps({type: 'radio'});
     expect(button.type).toEqual('input');

--- a/media/js/src/viewer-main.js
+++ b/media/js/src/viewer-main.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { MathJaxContext } from 'better-react-mathjax';
 import Viewer from './Viewer.jsx';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
-root.render(<Viewer />);
+root.render(
+    <MathJaxContext>
+        <Viewer />
+    </MathJaxContext>
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "license": "GPL-3.0+",
       "dependencies": {
+        "better-react-mathjax": "~2.0.3",
         "commonmark": "0.31.0",
         "decimal.js": "nikolas/decimal.js#export-fix",
         "jsxgraph": "~1.8.0",
-        "mathjax3-react": "~1.2.0",
         "mathjs": "^12.4.0",
         "object-assign": "~4.1.1",
         "promise": "~8.3.0",
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.1.tgz",
-      "integrity": "sha512-o7SDgTJuvx5vLKD6SFvkydkSMBvahDKGiNJzG22IZYXhiqoe9efY7zocICBgzHV4IRg5wdgl2nEL/tulKIEIbA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
+      "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
@@ -3053,9 +3053,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.7.tgz",
-      "integrity": "sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3137,9 +3137,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.6.tgz",
-      "integrity": "sha512-3KurE8taB8GCvZBPngVbp0lk5CKi8M9f9k1rsADh0Evdz5SzJ+Q+Hx9uHoFGsLnLnd1xmkDQr2hVhlA0Mn0lKQ==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4044,13 +4044,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.10.tgz",
-      "integrity": "sha512-rpIuu//y5OX6jVU+a5BCn1R5RSZYWAl2Nar76iwaOdycqb6JPxediskWFMMl7stfwNJR4b7eiQvh5fB5TEQJTQ==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
+      "integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.1",
+        "@babel/helper-define-polyfill-provider": "^0.6.2",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -4071,12 +4071,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.1.tgz",
-      "integrity": "sha512-JfTApdE++cgcTWjsiCQlLyFBMbTUft9ja17saCc93lgV33h4tuCVj7tlvu//qpLwaG+3yEz7/KhahGrUMkVq9g==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
+      "integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.1"
+        "@babel/helper-define-polyfill-provider": "^0.6.2"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -4126,6 +4126,17 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/better-react-mathjax": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/better-react-mathjax/-/better-react-mathjax-2.0.3.tgz",
+      "integrity": "sha512-wfifT8GFOKb1TWm2+E50I6DJpLZ5kLbch283Lu043EJtwSv0XvZDjr4YfR4d2MjAhqP6SH4VjjrKgbX8R00oCQ==",
+      "dependencies": {
+        "mathjax-full": "^3.2.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
     },
     "node_modules/bfj": {
       "version": "8.0.0",
@@ -4369,9 +4380,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001607",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
-      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "funding": [
         {
           "type": "opencollective",
@@ -4599,9 +4610,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
@@ -4657,9 +4671,9 @@
       "dev": true
     },
     "node_modules/core-js-compat": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
-      "integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
+      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.23.0"
@@ -4966,9 +4980,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
-      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
+      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
       "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -5180,9 +5194,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.730",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.730.tgz",
-      "integrity": "sha512-oJRPo82XEqtQAobHpJIR3zW5YO3sSRRkPz2an4yxi1UvqhsGm54vR/wzTFV74a3soDOJ8CKW7ajOOX5ESzddwg=="
+      "version": "1.4.747",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.747.tgz",
+      "integrity": "sha512-+FnSWZIAvFHbsNVmUxhEqWiaOiPMcfum1GQzlWCg/wLigVtshOsjXHyEFfmt6cFK6+HkS3QOJBv6/3OPumbBfw=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6032,6 +6046,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/espree": {
@@ -10231,15 +10253,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mathjax3-react": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mathjax3-react/-/mathjax3-react-1.2.0.tgz",
-      "integrity": "sha512-1FLk0OiHEW4EdIRKIR9SgvjN/XtglnKgnNF/vF/bkkLypVkitFCTFDOneEl3cXU6fJebNI7AP0xE8ZQE5JhS1g==",
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
       "dependencies": {
-        "simple-load-script": "2.0.0"
-      },
-      "peerDependencies": {
-        "react": "18.x"
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
       }
     },
     "node_modules/mathjs": {
@@ -10344,6 +10366,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ=="
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -10542,6 +10569,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -11193,9 +11225,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.9.tgz",
+      "integrity": "sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==",
       "dev": true
     },
     "node_modules/object-assign": {
@@ -13075,11 +13107,6 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/simple-load-script": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-load-script/-/simple-load-script-2.0.0.tgz",
-      "integrity": "sha512-KYlKaZH7jW4pI5zHZxwFuERrYZZIIQDOOz+zgB70+Xt69EHoFJ4kkyyJk1PfpUvOHLRyz3PSwDAUEIlfRQKNow=="
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -13151,9 +13178,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.2.tgz",
-      "integrity": "sha512-5Hvyu6Md91ooZzdrN/bSn/zlulFaRHrk2/6IY6qQNa3oVHTiG+CKxBV5PynKCGf31ar+3/hyPvlHFAYaBEOa3A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -13237,6 +13264,19 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
       "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
       "dev": true
+    },
+    "node_modules/speech-rule-engine": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
+      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
+      "dependencies": {
+        "commander": "9.2.0",
+        "wicked-good-xpath": "1.3.0",
+        "xmldom-sre": "0.1.31"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -13595,9 +13635,9 @@
       "dev": true
     },
     "node_modules/terser": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
-      "integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
+      "version": "5.30.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
+      "integrity": "sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -13695,6 +13735,11 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/terser/node_modules/source-map-support": {
       "version": "0.5.21",
@@ -13991,9 +14036,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -14553,6 +14598,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -14680,6 +14730,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
+      "engines": {
+        "node": ">=0.1"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "commonmark": "0.31.0",
     "decimal.js": "nikolas/decimal.js#export-fix",
     "jsxgraph": "~1.8.0",
-    "mathjax3-react": "~1.2.0",
+    "better-react-mathjax": "~2.0.3",
     "mathjs": "^12.4.0",
     "object-assign": "~4.1.1",
     "promise": "~8.3.0",


### PR DESCRIPTION
There are many react/mathjax component libraries and none of them are really "officially" maintained, so it's a bit of trial and error to find one that works best.

I actually wasn't able to directly reproduce the issue in the ECON-662 ticket in my browsers (Firefox / Brave), but I have definitely been seeing mathjax warnings in the JS console, and just general performance weirdness with loading these componenents, so I've migrated to a different library to see if things behave better.