### PR TITLE
Fix JS error in graph form template

### DIFF
--- a/econplayground/templates/main/graph_form.html
+++ b/econplayground/templates/main/graph_form.html
@@ -14,7 +14,7 @@
         if (!window.EconPlayground) {
             window.EconPlayground = {};
         }
-        window.EconPlayground[graphType] =  {{graph_type}};
+        window.EconPlayground['graphType'] = {{graph_type}};
     </script>
     <script src="{% static 'js/build/editor.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
This change fixes the error:
> Uncaught ReferenceError: graphType is not defined

We need to treat `graphType` as a string here, as it is a variable name, and undefined in this context.