### PR TITLE
Allow grid options to be optional in JXGBoard

### DIFF
--- a/media/js/src/JXGBoard.jsx
+++ b/media/js/src/JXGBoard.jsx
@@ -512,6 +512,19 @@ export default class JXGBoard extends React.Component {
             boundingBox = [0, 12000, 500, 0];
         }
 
+        let grid = false;
+        if (
+            typeof this.props.gMajorGridType !== 'undefined' &&
+                typeof this.props.gMinorGridType !== 'undefined'
+        ) {
+            grid = {
+                major: GRID_MAJOR[this.props.gMajorGridType],
+                minor: GRID_MINOR[this.props.gMinorGridType],
+                minorElements: 1,
+                visible: true
+            };
+        }
+
         this.board = JXG.JSXGraph.initBoard(
             this.id, {
                 axis: true,
@@ -535,12 +548,7 @@ export default class JXGBoard extends React.Component {
                         layer: 9
                     }
                 },
-                grid: {
-                    major: GRID_MAJOR[this.props.gMajorGridType],
-                    minor: GRID_MINOR[this.props.gMinorGridType],
-                    minorElements: 1,
-                    visible: true,
-                },
+                grid: grid,
                 keepAspectRatio: false,
                 showCopyright: false,
                 showZoom: false,


### PR DESCRIPTION
These grid options aren't technically required for displaying the graph, and aren't marked is `isRequired` in the props, so these changes fix the case where the code would fail if they aren't present.

In practice, this is not likely to happen as we have populated all grid types as 0 by default. Still, for most of the graph types that aren't using the grid yet, it is possible for them to render a JXGBoard without passing in these options.