### PR TITLE
Put graph settings checkboxes in two columns

### DIFF
--- a/media/js/src/editors/CommonGraphSettings.jsx
+++ b/media/js/src/editors/CommonGraphSettings.jsx
@@ -77,67 +77,75 @@ export default class CommonGraphSettings extends React.Component {
                         <option value={1}>LTI Assessment</option>
                     </select>
                 </div>
-                <div className="form-check">
-                    <label className="form-check-label">
-                        <input
-                            id="gDisplayFeedback"
-                            className="form-check-input"
-                            type="checkbox"
-                            onChange={handleFormUpdate.bind(this)}
-                            checked={this.props.gDisplayFeedback} />
-                        Display feedback
-                    </label>
+
+                <div className="row">
+                    <div className="col">
+                        <div className="form-check">
+                            <label className="form-check-label">
+                                <input
+                                    id="gDisplayFeedback"
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    checked={this.props.gDisplayFeedback} />
+                                Display feedback
+                            </label>
+                        </div>
+                        <div className="form-check">
+                            <label className="form-check-label">
+                                <input
+                                    id="gShowIntersection"
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    checked={this.props.gShowIntersection} />
+                                Display intersection
+                            </label>
+                        </div>
+                        <div className="form-check">
+                            <label className="form-check-label">
+                                <input
+                                    id="gIsPublished"
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    checked={this.props.gIsPublished} />
+                                Published
+                            </label>
+                        </div>
+                    </div>
+                    <div className="col">
+                        <div className="form-check">
+                            <label className="form-check-label">
+                                <input
+                                    id="gIsFeatured"
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    checked={this.props.gIsFeatured} />
+                                Featured
+                            </label>
+                        </div>
+                        <div className="form-check">
+                            <label className="form-check-label">
+                                <input
+                                    id="gDisplayShadow"
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    checked={this.props.gDisplayShadow} />
+                                Display shadow on student view
+                            </label>
+                        </div>
+                    </div>
                 </div>
-                <div className="form-check">
-                    <label className="form-check-label">
-                        <input
-                            id="gShowIntersection"
-                            className="form-check-input"
-                            type="checkbox"
-                            onChange={handleFormUpdate.bind(this)}
-                            checked={this.props.gShowIntersection} />
-                        Display intersection
-                    </label>
-                </div>
-                <div className="form-check">
-                    <label className="form-check-label">
-                        <input
-                            id="gIsPublished"
-                            className="form-check-input"
-                            type="checkbox"
-                            onChange={handleFormUpdate.bind(this)}
-                            checked={this.props.gIsPublished} />
-                        Published
-                    </label>
-                </div>
-                <div className="form-check">
-                    <label className="form-check-label">
-                        <input
-                            id="gIsFeatured"
-                            className="form-check-input"
-                            type="checkbox"
-                            onChange={handleFormUpdate.bind(this)}
-                            checked={this.props.gIsFeatured} />
-                        Featured
-                    </label>
-                </div>
-                <div className="form-check">
-                    <label className="form-check-label">
-                        <input
-                            id="gDisplayShadow"
-                            className="form-check-input"
-                            type="checkbox"
-                            onChange={handleFormUpdate.bind(this)}
-                            checked={this.props.gDisplayShadow} />
-                        Display shadow on student view
-                    </label>
-                </div>
+
                 <div>
                     <a
                         target="_blank"
                         rel="noreferrer"
                         role="button"
-                        className="btn btn-sm btn-primary mt-2 me-2"
+                        className="btn btn-sm btn-primary me-2"
                         title="Feedback and Assessment editor"
                         href={assessmentUrl}>
                         Feedback and Assessment editor


### PR DESCRIPTION
I am just consolidating some vertical space here - it has always bothered me that the graph-specific settings are pushed down in the page in the right column of the graph editor. I think there is some empty space we can re-claim in these general graph settings, possibly with the dropdown choices as well.

![Screenshot_2024-07-17_11-41-04](https://github.com/user-attachments/assets/df8978b1-e1d2-4073-834f-da60d01fa119)
