### PR TITLE
CommonGraphSettings: convert "Assessment Type" to a checkbox

### DIFF
--- a/media/js/src/editors/CommonGraphSettings.jsx
+++ b/media/js/src/editors/CommonGraphSettings.jsx
@@ -38,44 +38,40 @@ export default class CommonGraphSettings extends React.Component {
         return (
             <div>
                 <h2>Assignment</h2>
-                <div className="form-group">
-                    <label htmlFor="gAssignmentType">
-                        Type
-                    </label>
-                    <select id="gAssignmentType"
-                        className="form-select form-control-sm"
-                        onChange={handleFormUpdate.bind(this)}
-                        value={this.props.gAssignmentType}>
-                        <option value="0">Template assignment</option>
-                        <option value="1">Labeling assignment</option>
-                        <option value="2">Modification assignment</option>
-                    </select>
-                </div>
-                <div className="form-group">
-                    <label htmlFor="gTopic">
-                        Topic
-                    </label>
-                    <select
-                        id="gTopic"
-                        className="form-select form-control-sm"
-                        onChange={handleFormUpdate.bind(this)}
-                        value={this.props.gTopic || 0}>
-                        {this.state.topics.map(e => (
-                            <option key={e.pk} value={e.pk}>{e.name}</option>
-                        ))}
-                    </select>
-                </div>
-                <div className="form-group">
-                    <label htmlFor="gNeedsSubmit">
-                Assessment Type
-                    </label>
-                    <select id="gNeedsSubmit"
-                        className="form-select form-control-sm"
-                        onChange={handleFormUpdate.bind(this)}
-                        value={(this.props.gNeedsSubmit ? 1 : 0)}>
-                        <option value={0}>Practice assessment</option>
-                        <option value={1}>LTI Assessment</option>
-                    </select>
+
+                <div className="row">
+                    <div className="col">
+                        <div className="form-group">
+                            <label htmlFor="gAssignmentType">
+                                Type
+                            </label>
+                            <select
+                                id="gAssignmentType"
+                                className="form-select form-control-sm"
+                                onChange={handleFormUpdate.bind(this)}
+                                value={this.props.gAssignmentType}>
+                                <option value="0">Template assignment</option>
+                                <option value="1">Labeling assignment</option>
+                                <option value="2">Modification assignment</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div className="col">
+                        <div className="form-group">
+                            <label htmlFor="gTopic">
+                                Topic
+                            </label>
+                            <select
+                                id="gTopic"
+                                className="form-select form-control-sm"
+                                onChange={handleFormUpdate.bind(this)}
+                                value={this.props.gTopic || 0}>
+                                {this.state.topics.map(e => (
+                                    <option key={e.pk} value={e.pk}>{e.name}</option>
+                                ))}
+                            </select>
+                        </div>
+                    </div>
                 </div>
 
                 <div className="row">
@@ -135,6 +131,17 @@ export default class CommonGraphSettings extends React.Component {
                                     onChange={handleFormUpdate.bind(this)}
                                     checked={this.props.gDisplayShadow} />
                                 Display shadow on student view
+                            </label>
+                        </div>
+                        <div className="form-check">
+                            <label className="form-check-label">
+                                <input
+                                    id="gNeedsSubmit"
+                                    className="form-check-input"
+                                    type="checkbox"
+                                    onChange={handleFormUpdate.bind(this)}
+                                    checked={this.props.gNeedsSubmit} />
+                                LTI assessment
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
This dropdown only has two states: Practice and LTI. This can easily be a checkbox. This also simplifies the wording as there is already a "Type" dropdown in this assignment area.

Also, I put the Type and Topic dropdowns in a single row.

![Screenshot_2024-07-17_13-25-48](https://github.com/user-attachments/assets/17fd19b2-bfd1-49a5-b260-0bb2d6962a47)
