### PR TITLE
CommonGraphSettings: remove unused form-control-sm on dropdowns

### DIFF
--- a/media/js/src/editors/CommonGraphSettings.jsx
+++ b/media/js/src/editors/CommonGraphSettings.jsx
@@ -47,7 +47,7 @@ export default class CommonGraphSettings extends React.Component {
                             </label>
                             <select
                                 id="gAssignmentType"
-                                className="form-select form-control-sm"
+                                className="form-select"
                                 onChange={handleFormUpdate.bind(this)}
                                 value={this.props.gAssignmentType}>
                                 <option value="0">Template assignment</option>
@@ -63,7 +63,7 @@ export default class CommonGraphSettings extends React.Component {
                             </label>
                             <select
                                 id="gTopic"
-                                className="form-select form-control-sm"
+                                className="form-select"
                                 onChange={handleFormUpdate.bind(this)}
                                 value={this.props.gTopic || 0}>
                                 {this.state.topics.map(e => (


### PR DESCRIPTION
This value should be `form-select-sm`, as `form-control-sm` doesn't seem to do anything on a select element. I'm just going to remove this class for now and leave these at the size they are, which is fine.