### PR TITLE
Use katex in RangeEditor #3308

### DIFF
--- a/econplayground/templates/base.html
+++ b/econplayground/templates/base.html
@@ -59,6 +59,10 @@
         crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
+          integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+"
+          crossorigin="anonymous">
 
     <!-- Font -->
     <link href="https://fonts.googleapis.com/css?family=Quattrocento+Sans" rel="stylesheet">

--- a/media/js/config/webpack.config.dev.cjs
+++ b/media/js/config/webpack.config.dev.cjs
@@ -82,7 +82,11 @@ module.exports = {
         ],
     },
     module: {
-        strictExportPresence: true,
+        parser: {
+            javascript: {
+                exportsPresence: 'warn'
+            }
+        },
         rules: [
             // TODO: Disable require.ensure as it's not a standard language feature.
             // We are waiting for https://github.com/facebookincubator/create-react-app/issues/2176.
@@ -107,11 +111,13 @@ module.exports = {
                     {
                         test: /\.(js|jsx)$/,
                         include: paths.appSrc,
-                        loader: require.resolve('babel-loader'),
-                        options: {
-
-                            compact: true,
-                        },
+                        exclude: /node_modules/,
+                        use: {
+                            loader: 'babel-loader',
+                            options: {
+                                presets: ['@babel/preset-env', '@babel/preset-react']
+                            }
+                        }
                     },
                     // "file" loader makes sure assets end up in the `build` folder.
                     // When you `import` an asset, you get its filename.
@@ -123,7 +129,7 @@ module.exports = {
                         // it's runtime that would otherwise processed through "file" loader.
                         // Also exclude `html` and `json` extensions so they get processed
                         // by webpacks internal loaders.
-                        exclude: [/\.js$/, /\.html$/, /\.json$/],
+                        exclude: [/\.js$/, /\.mjs$/, /\.html$/, /\.json$/, /node_modules/],
                         options: {
                             name: '[name].[ext]',
                         },

--- a/media/js/src/form-components/RangeEditor.js
+++ b/media/js/src/form-components/RangeEditor.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MathJax } from 'better-react-mathjax';
+import katex from 'katex';
 import { btnStep } from '../utils.js';
 
 /**
@@ -9,6 +9,26 @@ import { btnStep } from '../utils.js';
  * to allow the user to override that value.
  */
 export default class RangeEditor extends React.Component {
+    label() {
+        if (!this.props.label) {
+            return null;
+        }
+
+        if (!this.props.rawLabel) {
+            const renderedLatex = katex.renderToString(this.props.label, {
+                throwOnError: false
+            });
+            return (
+                <span dangerouslySetInnerHTML={{__html: renderedLatex}}>
+                </span>
+            );
+        } else {
+            return (
+                <span>{this.props.label}</span>
+            );
+        }
+    }
+
     render() {
         return (
             <React.Fragment>
@@ -17,18 +37,7 @@ export default class RangeEditor extends React.Component {
                         <div className="form-row">
                             <label key="dataId" className="w-100" htmlFor={this.props.id}>
 
-                                {this.props.label && this.props.rawLabel && (
-                                    <label htmlFor={this.props.id}>
-                                        {this.props.label}
-                                    </label>
-                                )}
-                                {this.props.label && !this.props.rawLabel && (
-                                    <div style={{display: 'flex'}}>
-                                        <MathJax>
-                                            {'$$' + this.props.label + '$$'}
-                                        </MathJax>
-                                    </div>
-                                )}
+                                {this.label()}
 
                                 <div className="d-inline w-100">
                                     {this.props.showMinMax && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commonmark": "0.31.0",
         "decimal.js": "nikolas/decimal.js#export-fix",
         "jsxgraph": "~1.9.0",
+        "katex": "^0.16.11",
         "mathjs": "^13.0.0",
         "object-assign": "~4.1.1",
         "promise": "~8.3.0",
@@ -8932,6 +8933,29 @@
       "license": "(MIT OR LGPL-3.0-or-later)",
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
+      "integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   },
   "homepage": "https://github.com/ccnmtl/econplayground#readme",
   "dependencies": {
+    "better-react-mathjax": "~2.0.3",
     "commonmark": "0.31.0",
     "decimal.js": "nikolas/decimal.js#export-fix",
     "jsxgraph": "~1.9.0",
-    "better-react-mathjax": "~2.0.3",
+    "katex": "^0.16.11",
     "mathjs": "^13.0.0",
     "object-assign": "~4.1.1",
     "promise": "~8.3.0",


### PR DESCRIPTION
I've updated this component to use katex directly instead of better-react-mathjax. It appears to fix the issue in graph type 21 where the toggle broke the latex display in the gA3 value's label.

If this works well I'll adapt the other parts of the code to use this too.