### PR TITLE
webpack: Separate vendored code into vendor.js

### DIFF
--- a/econplayground/templates/assignment/assignment_question_create.html
+++ b/econplayground/templates/assignment/assignment_question_create.html
@@ -23,6 +23,7 @@
 {% endblock %}
 
 {% block js %}
+    <script src="{% static 'js/build/vendor.js' %}"></script>
     <script src="{% static 'js/build/rubric.js' %}"></script>
     <script src="{% static 'js/build/multipleChoice.js' %}"></script>
     <script src="{% static 'js/build/graphPreview.js' %}"></script>

--- a/econplayground/templates/assignment/assignment_question_preview.html
+++ b/econplayground/templates/assignment/assignment_question_preview.html
@@ -39,6 +39,7 @@
     {% endif %}
     </script>
     {% if object.graph %}
+        <script src="{% static 'js/build/vendor.js' %}"></script>
         <script src="{% static 'js/build/stepGraphViewer.js' %}"></script>
     {% endif %}
 {% endblock %}

--- a/econplayground/templates/assignment/questions_list.html
+++ b/econplayground/templates/assignment/questions_list.html
@@ -53,6 +53,7 @@
 {% endblock %}
 
 {% block js %}
+    <script src="{% static 'js/build/vendor.js' %}"></script>
     <script src="{% static 'js/build/rubric.js' %}"></script>
     <script src="{% static 'js/build/multipleChoice.js' %}"></script>
     <script src="{% static 'js/build/graphPreview.js' %}"></script>

--- a/econplayground/templates/assignment/step_detail.html
+++ b/econplayground/templates/assignment/step_detail.html
@@ -49,6 +49,7 @@
     {% endif %}
     </script>
     {% if object.question.graph %}
+        <script src="{% static 'js/build/vendor.js' %}"></script>
         <script src="{% static 'js/build/stepGraphViewer.js' %}"></script>
     {% endif %}
 {% endblock %}

--- a/econplayground/templates/main/graph_detail.html
+++ b/econplayground/templates/main/graph_detail.html
@@ -24,6 +24,7 @@
     {% endif %}
     window.EconPlayground['LTIPostGrade'] = '{% url 'lti-post-grade' %}';
     </script>
+    <script src="{% static 'js/build/vendor.js' %}"></script>
     <script src="{% static 'js/build/viewer.js' %}"></script>
 {% endblock %}
 

--- a/econplayground/templates/main/graph_embed.html
+++ b/econplayground/templates/main/graph_embed.html
@@ -29,6 +29,7 @@
                 window.EconPlayground['EmbedSuccess'] = '{% url 'graph_embed' object.pk %}?submitted=1';
                 window.EconPlayground['EmbedLaunchUrl'] = '{% url 'graph_embed' object.pk %}?submitted=1';
                 </script>
+                <script src="{% static 'js/build/vendor.js' %}"></script>
                 <script src="{% static 'js/build/viewer.js' %}"></script>
             </div>
         </div>

--- a/econplayground/templates/main/graph_embed_public.html
+++ b/econplayground/templates/main/graph_embed_public.html
@@ -24,6 +24,7 @@
     window.EconPlayground['isInstructor'] = false;
     window.EconPlayground['hideTitleAndInstructions'] = false;
     </script>
+    <script src="{% static 'js/build/vendor.js' %}"></script>
     <script src="{% static 'js/build/viewer.js' %}"></script>
 {% endblock %}
 

--- a/econplayground/templates/main/graph_embed_public_minimal.html
+++ b/econplayground/templates/main/graph_embed_public_minimal.html
@@ -25,6 +25,7 @@
                 window.EconPlayground['isInstructor'] = false;
                 window.EconPlayground['hideTitleAndInstructions'] = true;
                 </script>
+                <script src="{% static 'js/build/vendor.js' %}"></script>
                 <script src="{% static 'js/build/viewer.js' %}"></script>
             </div>
         </div>

--- a/econplayground/templates/main/graph_form.html
+++ b/econplayground/templates/main/graph_form.html
@@ -16,6 +16,7 @@
         }
         window.EconPlayground['graphType'] = {{graph_type}};
     </script>
+    <script src="{% static 'js/build/vendor.js' %}"></script>
     <script src="{% static 'js/build/editor.js' %}"></script>
 {% endblock %}
 

--- a/media/js/config/webpack.config.dev.cjs
+++ b/media/js/config/webpack.config.dev.cjs
@@ -138,6 +138,12 @@ module.exports = {
             },
         ],
     },
+    optimization: {
+        splitChunks: {
+            chunks: 'all',
+            name: 'vendor'
+        },
+    },
     plugins: [
         // Makes some environment variables available to the JS code, for example:
         // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.

--- a/media/js/config/webpack.config.prod.cjs
+++ b/media/js/config/webpack.config.prod.cjs
@@ -95,6 +95,12 @@ module.exports = {
             }
         ]
     },
+    optimization: {
+        splitChunks: {
+            chunks: 'all',
+            name: 'vendor'
+        },
+    },
     plugins: [
         // Makes some environment variables available to the JS code, for example:
         // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.
@@ -109,6 +115,6 @@ module.exports = {
         new webpack.IgnorePlugin({
             resourceRegExp: /^\.\/locale$/,
             contextRegExp: /moment$/
-        }),
+        })
     ]
 };


### PR DESCRIPTION
There is much common code compiled by webpack into our separate react applications, causing the same code to be downloaded by the browser multiple times in different forms. We can avoid this by putting all library code into a separate `vendor.js` file, which the application can then load regardless of if we're displaying the Viewer, Editor, Rubric, or GraphPreview, etc. The browser will cache this file during a user's session and only have to download it once.

https://webpack.js.org/plugins/split-chunks-plugin/