### PR TITLE
Taxation in Linear Demand/Supply: implement display basics

### DIFF
--- a/media/js/src/Editor.jsx
+++ b/media/js/src/Editor.jsx
@@ -122,11 +122,15 @@ class Editor extends Component {
                 updateObj.gXAxisMax = 1000;
                 updateObj.gYAxisMax = 1000;
             } else if (window.EconPlayground.graphType === 23) {
-                updateObj.gA1 = 1500;
-                updateObj.gA2 = 100;
-                updateObj.gA3 = 0;
-                updateObj.gLine1Slope = 2;
-                updateObj.gLine2Slope = -2;
+                Object.assign(updateObj, {
+                    gA1: 1500,
+                    gA2: 100,
+                    gA3: 0,
+                    gLine1Slope: 2,
+                    gLine2Slope: -2,
+                    gXAxisMax: 1000,
+                    gYAxisMax: 2500
+                });
             }
 
             this.setState(updateObj);

--- a/media/js/src/JXGBoard.jsx
+++ b/media/js/src/JXGBoard.jsx
@@ -528,6 +528,10 @@ export default class JXGBoard extends React.Component {
                 xAxisLabel = 'Unit Tax';
                 yAxisLabel = 'Tax Revenue';
                 break;
+            case 23:
+                xTicks = this.visibleTicks;
+                yTicks = xTicks;
+                break;
             default:
                 xAxisLabel = options.gXAxisLabel ? options.gXAxisLabel : 'x';
                 yAxisLabel = options.gYAxisLabel ? options.gYAxisLabel : 'y';

--- a/media/js/src/editors/TaxationLinearDemandEditor.jsx
+++ b/media/js/src/editors/TaxationLinearDemandEditor.jsx
@@ -5,8 +5,39 @@ import { handleFormUpdate } from '../utils.js';
 
 export default class TaxationLinearDemandEditor extends React.Component {
     render() {
+        const radioButtons = (
+            <>
+                <div className="form-check form-check-inline">
+                    <input
+                        type="radio" id="functionChoice-0"
+                        className="form-check-input"
+                        value={0}
+                        name="gFunctionChoice"
+                        checked={this.props.gFunctionChoice === 0}
+                        onChange={handleFormUpdate.bind(this)} />
+                    <label className="form-check-label" htmlFor="functionChoice-0">
+                        Unit Tax
+                    </label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input
+                        type="radio" id="functionChoice-1"
+                        className="form-check-input"
+                        value={1}
+                        name="gFunctionChoice"
+                        checked={this.props.gFunctionChoice === 1}
+                        onChange={handleFormUpdate.bind(this)} />
+                    <label className="form-check-label" htmlFor="functionChoice-1">
+                        Ad Valorem Tax
+                    </label>
+                </div>
+            </>
+        );
+
         return (
             <>
+                {radioButtons}
+
                 <RangeEditor
                     label="Choke Price"
                     rawLabel={true}
@@ -46,15 +77,30 @@ export default class TaxationLinearDemandEditor extends React.Component {
                     min={0.01}
                     max={35}
                     handler={handleFormUpdate.bind(this)} />
-                <RangeEditor
-                    label="Unit Tax"
-                    rawLabel={true}
-                    id="gA3"
-                    dataId="gA3"
-                    value={this.props.gA3}
-                    min={0}
-                    max={1500}
-                    handler={handleFormUpdate.bind(this)} />
+
+                {this.props.gFunctionChoice === 0 && (
+                    <RangeEditor
+                        label="Unit Tax"
+                        rawLabel={true}
+                        id="gA3"
+                        dataId="gA3"
+                        value={this.props.gA3}
+                        min={0}
+                        max={1500}
+                        handler={handleFormUpdate.bind(this)} />
+                )}
+
+                {this.props.gFunctionChoice === 1 && (
+                    <RangeEditor
+                        label="Tax Rate"
+                        rawLabel={true}
+                        id="gA3"
+                        dataId="gA3"
+                        value={this.props.gA3}
+                        min={0}
+                        max={2}
+                        handler={handleFormUpdate.bind(this)} />
+                )}
             </>
         );
     }
@@ -67,5 +113,7 @@ TaxationLinearDemandEditor.propTypes = {
     gA2: PropTypes.number.isRequired,
     gA3: PropTypes.number.isRequired,
     gLine1Slope: PropTypes.number.isRequired,
-    gLine2Slope: PropTypes.number.isRequired
+    gLine2Slope: PropTypes.number.isRequired,
+
+    gFunctionChoice: PropTypes.number.isRequired
 };

--- a/media/js/src/graphs/DemandSupplyGraph.js
+++ b/media/js/src/graphs/DemandSupplyGraph.js
@@ -79,7 +79,8 @@ export class DemandSupplyGraph extends Graph {
                 },
                 strokeColor: this.l1Color,
                 strokeWidth: 2,
-                fixed: this.areLinesFixed
+                fixed: this.areLinesFixed,
+                highlight: !this.areLinesFixed
             });
 
         this.l2 = this.board.create(
@@ -107,7 +108,8 @@ export class DemandSupplyGraph extends Graph {
                 },
                 strokeColor: this.l2Color,
                 strokeWidth: 2,
-                fixed: this.areLinesFixed
+                fixed: this.areLinesFixed,
+                highlight: !this.areLinesFixed
             });
 
         if (this.options.gShowIntersection) {

--- a/media/js/src/graphs/DemandSupplyGraphAUC.js
+++ b/media/js/src/graphs/DemandSupplyGraphAUC.js
@@ -9,7 +9,7 @@ import {
     AREA_A_COLOR, AREA_B_COLOR, AREA_C_COLOR
 } from './Graph.js';
 
-class DemandSupplyGraphAUC extends DemandSupplyGraph {
+export class DemandSupplyGraphAUC extends DemandSupplyGraph {
     drawAreaA(shadow=false, areaConf, intersection, l2) {
         if (!l2) {
             console.error('error: l2 is missing!');

--- a/media/js/src/graphs/Graph.js
+++ b/media/js/src/graphs/Graph.js
@@ -146,7 +146,9 @@ export class Graph {
         const me = this;
 
         if (
-            this.l1 && (typeof this.l1.getRise === 'function') &&
+            this.l1 &&
+                !this.options.locked &&
+                typeof this.l1.getRise === 'function' &&
                 !this.options.isSubmitted
         ) {
             this.initialL1Y = this.l1.getRise();
@@ -186,7 +188,9 @@ export class Graph {
         }
 
         if (
-            this.l2 && (typeof this.l2.getRise === 'function') &&
+            this.l2 &&
+                !this.options.locked &&
+                typeof this.l2.getRise === 'function' &&
                 !this.options.isSubmitted
         ) {
             this.initialL2Y = this.l2.getRise();

--- a/media/js/src/graphs/TaxationLinearDemandSupplyGraph.js
+++ b/media/js/src/graphs/TaxationLinearDemandSupplyGraph.js
@@ -1,0 +1,26 @@
+import {DemandSupplyGraphAUC} from './DemandSupplyGraphAUC.js';
+
+class TaxationLinearDemandSupplyGraph extends DemandSupplyGraphAUC {
+    constructor(board, options, defaults) {
+        super(board, options, defaults);
+
+        this.center = options.gXAxisMax / 2;
+    }
+}
+
+export const mkTaxationLinearDemandSupply = function(board, options) {
+    options.locked = true;
+
+    // Shade in the two left areas.
+    options.gAreaConfiguration = 3;
+
+    options.gShowIntersection = true;
+    options.gIntersectionLabel = '(Q^t, p^d)';
+    options.gIntersectionHorizLineLabel = 'p^d';
+    options.gIntersectionVertLineLabel = 'Q^t';
+
+    let g = new TaxationLinearDemandSupplyGraph(board, options);
+    g.make();
+    g.postMake();
+    return g;
+};

--- a/media/js/src/graphs/graphTypes.js
+++ b/media/js/src/graphs/graphTypes.js
@@ -17,6 +17,9 @@ import { mkOptimalChoiceConsumption } from './OptimalChoiceConsumption.js';
 import { mkRevenueElasticity } from './RevenueElasticityGraph.js';
 import {mkOptimalChoiceCostMinimizing} from './OptimalChoiceCostMinimizing.js';
 import { mkTaxRevenue } from './TaxRevenueGraph.js';
+import {
+    mkTaxationLinearDemandSupply
+} from './TaxationLinearDemandSupplyGraph.js';
 
 export const graphTypes = [
     // There are some null graph types here because the number of
@@ -49,5 +52,5 @@ export const graphTypes = [
     mkOptimalChoiceCostMinimizing,
 
     mkTaxRevenue,
-    mkDemandSupplyAUC
+    mkTaxationLinearDemandSupply
 ];


### PR DESCRIPTION
I just wanted to get the basic structure in place here as I'm exploring the possibility of re-using the DemandSupplyGraphAUC graph class for this new graph type. There is still more work to do to get it to match the mathematica interactive.

![Screenshot_2024-07-22_15-11-33](https://github.com/user-attachments/assets/2dfb37a6-e3b2-40fc-b4d0-20bc46501a28)
