### PR TITLE
RangeEditor: use div instead of span for rawLabel

### DIFF
--- a/media/js/src/form-components/RangeEditor.js
+++ b/media/js/src/form-components/RangeEditor.js
@@ -18,7 +18,7 @@ export default class RangeEditor extends React.Component {
             return getKatexEl(this.props.label);
         } else {
             return (
-                <span>{this.props.label}</span>
+                <div>{this.props.label}</div>
             );
         }
     }


### PR DESCRIPTION
This text will generally be on its own line. Fixes a style issue with long text strings.