### PR TITLE
Update V_cost equation display in cost editors

### DIFF
--- a/media/js/src/editors/CostFunctionsTotalEditor.jsx
+++ b/media/js/src/editors/CostFunctionsTotalEditor.jsx
@@ -20,7 +20,7 @@ export default class CostFunctionsTotalEditor extends React.Component {
                         {getKatexEl(`F_{cost}=a=${this.props.gA1}`)}
                     </div>
                     <div>
-                        {getKatexEl('V_{cost}=Cost - F_{cost}')}
+                        {getKatexEl('V_{cost} = bx + cx^2')}
                     </div>
                 </div>
                 <hr />

--- a/media/js/src/editors/CostFunctionsUnitEditor.jsx
+++ b/media/js/src/editors/CostFunctionsUnitEditor.jsx
@@ -13,8 +13,10 @@ export default class CostFunctionsUnitEditor extends React.Component {
                             ${this.props.gA1}+
                             ${this.props.gA2}x+
                             ${this.props.gA3}x^2`;
+
         const func2 = `F_{cost}=a=${this.props.gA1}`;
-        const func3 = 'V_{cost} = Cost - F_{cost}';
+
+        const func3 = 'V_{cost} = bx + cx^2';
 
         return (
             <div>


### PR DESCRIPTION
This was requested by Tom for the Cost Functions: Total graph - I assume because it is a simplified version of the equation. I am guessing he wants these updated in both editors, but I will confirm this in our next check-in.