### PR TITLE
Perfect Substitutes + Perfect Complements fixes

### DIFF
--- a/media/js/src/graphs/OptimalChoiceCostMinimizing.js
+++ b/media/js/src/graphs/OptimalChoiceCostMinimizing.js
@@ -211,19 +211,29 @@ const isoq5 = function(l, q, a, b) {
 };
 
 const f5s = function(l, w, r, q, a, b) {
-    return -l * w / r + q * w / (b * r) + q / a;
+    let qaStar = 0;
+    if (a * w < b * r) {
+        qaStar = q / a;
+    }
+
+    let qbStar = 0;
+    if (a * w < b * r) {
+        qbStar = q / b;
+    }
+
+    return ((-l) * w + r * (qaStar) + w * (qbStar)) / r;
 };
 
-const kStarValue5 = function(q, w, r, a, b) {
-    if (a * w < b * r) {
+const lStarValue5 = function(q, w, r, a, b) {
+    if (a * w > b * r) {
         return q / b;
     } else {
         return 0;
     }
 };
 
-const lStarValue5 = function(q, w, r, a, b) {
-    if (a * w > b * r) {
+const kStarValue5 = function(q, w, r, a, b) {
+    if (a * w < b * r) {
         return q / a;
     } else {
         return 0;
@@ -245,15 +255,13 @@ const isoq6 = function(l, q, a, b) {
     }
 };
 
-const kStarValue6 = function(q, w, r, a, b) {
+const lStarValue6 = function(q, w, r, a, b) {
     return q / b;
 };
 
-const lStarValue6 = function(q, w, r, a, b) {
+const kStarValue6 = function(q, w, r, a, b) {
     return q / a;
 };
-
-
 
 const optimalBundleColor = 'red';
 
@@ -399,7 +407,19 @@ export class OptimalChoiceCostMinimizingGraph extends Graph {
 
             this.l2 = this.board.create(
                 'functiongraph',
-                [isoquantLine, 0, this.options.gXAxisMax], {
+                [function(x) {
+                    const result = isoquantLine(x);
+
+                    // Don't render line below 0.
+                    // In jsxgraph we can restrict a functiongraph
+                    // (i.e. a Curve object) by returning NaN.
+                    // https://groups.google.com/g/jsxgraph/c/jhEaxh225VA/m/75LAkgTdBQAJ
+                    if (result < 0) {
+                        return NaN;
+                    }
+
+                    return result;
+                }, 0, this.options.gXAxisMax], {
                     name: 'Isoquant Q^* = ' + this.options.gA3,
                     withLabel: true,
                     label: {
@@ -468,7 +488,19 @@ export class OptimalChoiceCostMinimizingGraph extends Graph {
 
         this.l1 = this.board.create(
             'functiongraph',
-            [isocostLine, 0, this.options.gXAxisMax], {
+            [function(x) {
+                const result = isocostLine(x);
+
+                // Don't render line below 0.
+                // In jsxgraph we can restrict a functiongraph
+                // (i.e. a Curve object) by returning NaN.
+                // https://groups.google.com/g/jsxgraph/c/jhEaxh225VA/m/75LAkgTdBQAJ
+                if (result < 0) {
+                    return NaN;
+                }
+
+                return result;
+            }, 0, this.options.gXAxisMax], {
                 strokeWidth: 2,
                 strokeColor: this.l1Color,
                 fixed: true,


### PR DESCRIPTION
* Correct some lStar/kStar mistakes
* I solved the f5s function using a trial version of mathematica, which yields a slightly different equation but pretty much the same results. The line appears to have the correct slope but the scale seems off. Things are still in progress here.
![Screenshot_2024-07-31_12-58-26](https://github.com/user-attachments/assets/239dd508-3c0b-4258-84d6-de82be5bafb2)

* Added a wrapper to the line rendering for all lines in this graph type to constrain the line to > 0 on the y-axis: https://groups.google.com/g/jsxgraph/c/jhEaxh225VA/m/75LAkgTdBQAJ