### PR TITLE
Fix Linear Demand Taxation editor

### DIFF
--- a/media/js/src/GraphEditor.jsx
+++ b/media/js/src/GraphEditor.jsx
@@ -148,7 +148,7 @@ export default class GraphEditor extends React.Component {
             </>
         );
 
-        if ([0, 9, 23].includes(this.props.gType)) {
+        if (this.props.gType === 0 || this.props.gType === 9) {
             // Demand-Supply, possibly AUC (area under curve)
             rightSide =
                 <DemandSupplyEditor


### PR DESCRIPTION
This should be displaying the TaxationLinearDemandEditor component rather than the DemandSupplyEditor.