### PR TITLE
Remove unnecessary CSS breakpoint classes

### DIFF
--- a/media/js/src/GraphEditor.jsx
+++ b/media/js/src/GraphEditor.jsx
@@ -114,7 +114,7 @@ export default class GraphEditor extends React.Component {
             <>
                 {jxgBoard}
 
-                <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                <div className="col-lg-6">
                     <h3>Scenario</h3>
                     <div className="form-group">
                         <label htmlFor="gTitle">
@@ -164,7 +164,7 @@ export default class GraphEditor extends React.Component {
                     <form>
                         <div className="row">
                             {common2Graph}
-                            <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                            <div className="col-lg-6">
                                 <DemandSupplyEditor
                                     showAUC={this.props.gType === 9}
                                     {...commonEditorProps}
@@ -188,7 +188,7 @@ export default class GraphEditor extends React.Component {
                     <form>
                         <div className="row">
                             {common2Graph}
-                            <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                            <div className="col-lg-6">
                                 <NonLinearDemandSupplyEditor
                                     hideFunctionChoice={true}
                                     showAUC={this.props.gType === 10}
@@ -315,7 +315,7 @@ export default class GraphEditor extends React.Component {
                     <form>
                         <div className="row">
                             {common2Graph}
-                            <div className="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-12">
+                            <div className="col-lg-6">
                                 <TaxRevenueEditor
                                     showAUC={this.props.gType === 9}
                                     {...commonEditorProps}

--- a/media/js/src/JXGBoard.jsx
+++ b/media/js/src/JXGBoard.jsx
@@ -734,7 +734,7 @@ export default class JXGBoard extends React.Component {
     // The primary HTML structure for JSXGraph
     makeFigure(id, hide, math) {
         return (
-            <div className="col-6" hidden={hide}>
+            <div className="col-lg-6" hidden={hide}>
                 <figure
                     aria-label="The EconPractice graph."
                     id={id}


### PR DESCRIPTION
It looks like these extra bootstrap classes here aren't necessary, and we can just use `col-lg-6`.

Also, I've changed the `col-6` on our JXGBoard component to `col-lg-6`, so this column disappears at this breakpoint, allowing full view of both boards on the joint graph type in smaller windows.