### PR TITLE
Cost Functions: Total: Fix initial values and graph scale

### DIFF
--- a/media/js/src/Editor.jsx
+++ b/media/js/src/Editor.jsx
@@ -1,14 +1,19 @@
 import React, { Component } from 'react';
 import GraphEditor from './GraphEditor.jsx';
 import { exportGraph, defaultGraph } from './GraphMapping.js';
-import {authedFetch, getError, getCohortId} from './utils.js';
 import {
     defaults as optimalChoiceConsumptionDefaults,
     untoggledDefaults as untoggledOptimalChoiceConsumptionDefaults
 } from './graphs/OptimalChoiceConsumption.js';
 import {
+    defaults as costFunctionsDefaults
+} from './graphs/CostFunctionsTotalGraph.js';
+import {
     defaults as costMinimizingDefaults
 } from './graphs/OptimalChoiceCostMinimizing.js';
+import {
+    authedFetch, getError, getCohortId, setDefaults
+} from './utils.js';
 
 class Editor extends Component {
     constructor(props) {
@@ -95,44 +100,21 @@ class Editor extends Component {
 
     handleGraphUpdate(obj) {
         if (this.state.gType === 17) {
-            if (Object.hasOwn(obj, 'gFunctionChoice')) {
-                Object.assign(
-                    obj,
-                    optimalChoiceConsumptionDefaults[obj.gFunctionChoice]);
-            }
-
-            if (Object.hasOwn(obj, 'gToggle')) {
-                // Update axis dynamically based on this toggle.
-                if (obj.gToggle) {
-                    Object.assign(
-                        obj,
-                        optimalChoiceConsumptionDefaults[
-                            this.state.gFunctionChoice]);
-                } else {
-                    Object.assign(
-                        obj,
-                        untoggledOptimalChoiceConsumptionDefaults[
-                            this.state.gFunctionChoice]);
-                }
-            }
+            obj = setDefaults(
+                obj, optimalChoiceConsumptionDefaults,
+                untoggledOptimalChoiceConsumptionDefaults,
+                this.state.gFunctionChoice);
+        } else if (this.state.gType === 18) {
+            obj = setDefaults(
+                obj, costFunctionsDefaults,
+                costFunctionsDefaults,
+                this.state.gFunctionChoice);
         } else if (this.state.gType === 21) {
-            if (Object.hasOwn(obj, 'gFunctionChoice')) {
-                Object.assign(
-                    obj,
-                    costMinimizingDefaults[obj.gFunctionChoice]);
-            }
-
-            if (Object.hasOwn(obj, 'gToggle')) {
-                // Update axis dynamically based on this toggle.
-                if (obj.gToggle) {
-                    Object.assign(
-                        obj,
-                        costMinimizingDefaults[this.state.gFunctionChoice]);
-                } else {
-                    obj.gXAxisMax = 1000;
-                    obj.gYAxisMax = 1000;
-                }
-            }
+            obj = setDefaults(
+                obj,
+                costMinimizingDefaults,
+                {gXAxisMax: 1000, gYAxisMax: 1000},
+                this.state.gFunctionChoice);
         }
 
         this.setState(obj);
@@ -148,11 +130,13 @@ class Editor extends Component {
             Object.assign(updateObj, this.defaults);
 
             // Specific defaults based on graph type.
-            if (window.EconPlayground.graphType === 17) {
+            if (window.EconPlayground.graphType === 15) {
+                updateObj.gA4 = 0.5;
+            } else if (window.EconPlayground.graphType === 17) {
                 Object.assign(
                     updateObj, untoggledOptimalChoiceConsumptionDefaults);
-            } else if (window.EconPlayground.graphType === 15) {
-                updateObj.gA4 = 0.5;
+            } else if (window.EconPlayground.graphType === 18) {
+                Object.assign(updateObj, costFunctionsDefaults[0]);
             } else if (window.EconPlayground.graphType === 21) {
                 Object.assign(updateObj, {
                     gA1: 5,

--- a/media/js/src/JXGBoard.jsx
+++ b/media/js/src/JXGBoard.jsx
@@ -37,10 +37,10 @@ const getNLDSXLabel = function(functionChoice, kName, nName) {
 const calculateBoundingBox = function(xAxisMin, yAxisMin, xAxisMax, yAxisMax) {
     return [
         // Margins depend on graph scale
-        yAxisMin - (yAxisMax * 0.014),
+        xAxisMin - (xAxisMax * 0.014),
         yAxisMax,
         xAxisMax,
-        xAxisMin - (xAxisMax * 0.022)
+        yAxisMin - (yAxisMax * 0.022)
     ];
 };
 
@@ -342,7 +342,7 @@ export default class JXGBoard extends React.Component {
         }
 
         if (needsUpdate) {
-            if (![18, 22, 24].includes(this.props.gType)) {
+            if (![22, 24].includes(this.props.gType)) {
                 let boundingBox = calculateBoundingBox(
                     this.props.gXAxisMin, this.props.gYAxisMin,
                     this.props.gXAxisMax, this.props.gYAxisMax);
@@ -551,6 +551,10 @@ export default class JXGBoard extends React.Component {
                 yAxisLabel = getNLDSYLabel(
                     0, options.gCobbDouglasKName, options.gNName);
                 break;
+            case 18:
+                xTicks = this.visibleTicks;
+                yTicks = xTicks;
+                break;
             case 19:
                 xTicks = this.visibleTicks;
                 yTicks = xTicks;
@@ -593,9 +597,7 @@ export default class JXGBoard extends React.Component {
             options.gXAxisMin, options.gYAxisMin,
             options.gXAxisMax, options.gYAxisMax);
 
-        if (options.gType === 18) {
-            boundingBox = [0, 12000, 500, 0];
-        } else if (options.gType === 22 || options.gType === 24) {
+        if (options.gType === 22 || options.gType === 24) {
             if (options.gFunctionChoice === 0) {
                 boundingBox = [options.gXAxisMin - 17, options.gYAxisMax,
                     options.gXAxisMax, options.gYAxisMin - 11000];

--- a/media/js/src/Viewer.jsx
+++ b/media/js/src/Viewer.jsx
@@ -4,11 +4,18 @@ import GraphEditor from './GraphEditor.jsx';
 import GraphViewer from './GraphViewer.jsx';
 import { exportGraph, importGraph, defaultGraph } from './GraphMapping.js';
 import {
+    defaults as optimalChoiceConsumptionDefaults,
+    untoggledDefaults as untoggledOptimalChoiceConsumptionDefaults
+} from './graphs/OptimalChoiceConsumption.js';
+import {
+    defaults as costFunctionsDefaults
+} from './graphs/CostFunctionsTotalGraph.js';
+import {
     defaults as costMinimizingDefaults
 } from './graphs/OptimalChoiceCostMinimizing.js';
 import {
     authedFetch, getGraphId, getCohortId, getAssessment,
-    getSubmission, getError
+    getSubmission, getError, setDefaults
 } from './utils.js';
 
 class Viewer extends Component {
@@ -214,24 +221,22 @@ class Viewer extends Component {
     }
 
     handleGraphUpdate(obj) {
-        if (this.state.gType === 21) {
-            if (Object.hasOwn(obj, 'gFunctionChoice')) {
-                Object.assign(
-                    obj,
-                    costMinimizingDefaults[obj.gFunctionChoice]);
-            }
-
-            if (Object.hasOwn(obj, 'gToggle')) {
-                // Update axis dynamically based on this toggle.
-                if (obj.gToggle) {
-                    Object.assign(
-                        obj,
-                        costMinimizingDefaults[this.state.gFunctionChoice]);
-                } else {
-                    obj.gXAxisMax = 1000;
-                    obj.gYAxisMax = 1000;
-                }
-            }
+        if (this.state.gType === 17) {
+            obj = setDefaults(
+                obj, optimalChoiceConsumptionDefaults,
+                untoggledOptimalChoiceConsumptionDefaults,
+                this.state.gFunctionChoice);
+        } else if (this.state.gType === 18) {
+            obj = setDefaults(
+                obj, costFunctionsDefaults,
+                costFunctionsDefaults,
+                this.state.gFunctionChoice);
+        } else if (this.state.gType === 21) {
+            obj = setDefaults(
+                obj,
+                costMinimizingDefaults,
+                {gXAxisMax: 1000, gYAxisMax: 1000},
+                this.state.gFunctionChoice);
         }
 
         this.setState(obj);

--- a/media/js/src/editors/CostFunctionsTotalEditor.jsx
+++ b/media/js/src/editors/CostFunctionsTotalEditor.jsx
@@ -8,7 +8,6 @@ export default class CostFunctionsTotalEditor extends React.Component {
     render() {
         return (
             <div>
-                <h3>Function</h3>
                 <div className="col">
                     <div>
                         {getKatexEl(`Cost=a+bx+cx^2=
@@ -32,7 +31,7 @@ export default class CostFunctionsTotalEditor extends React.Component {
                             dataId="gA1"
                             value={this.props.gA1}
                             min={0}
-                            max={4000}
+                            max={10000}
                             handler={handleFormUpdate.bind(this)} />
                         <RangeEditor
                             label="b"
@@ -40,7 +39,7 @@ export default class CostFunctionsTotalEditor extends React.Component {
                             dataId="gA2"
                             value={this.props.gA2}
                             min={0}
-                            max={1}
+                            max={30}
                             handler={handleFormUpdate.bind(this)} />
                         <RangeEditor
                             label="c"
@@ -48,7 +47,7 @@ export default class CostFunctionsTotalEditor extends React.Component {
                             dataId="gA3"
                             value={this.props.gA3}
                             min={0}
-                            max={1}
+                            max={30}
                             handler={handleFormUpdate.bind(this)} />
 
                     </React.Fragment>

--- a/media/js/src/graphs/CostFunctionsTotalGraph.js
+++ b/media/js/src/graphs/CostFunctionsTotalGraph.js
@@ -1,5 +1,21 @@
 import {Graph} from './Graph.js';
 
+export const defaults = [
+    {
+        gA1: 4000,
+        gA2: 1,
+        gA3: 1,
+        gXAxisMax: 500,
+        gYAxisMax: 10000
+    },
+    {
+        gA1: 2000,
+        gA2: 10,
+        gA3: 2,
+        gXAxisMax: 500,
+        gYAxisMax: 25000
+    }
+];
 
 const cost = function(q, a, b, c) {
     return a + (b * q) + (c * (q ** 2));
@@ -29,37 +45,37 @@ export class CostFunctionsTotalGraph extends Graph {
             return vcost(q, me.options.gA1, me.options.gA2, me.options.gA3);
         };
 
-        this.l1 = this.board.create('functiongraph', [f1, 0, 500], {
+        this.l1 = this.board.create('functiongraph', [
+            f1, 0, this.options.gXAxisMax
+        ], {
             name: 'TC',
             withLabel: true,
             strokeWidth: 2,
             strokeColor: this.l1Color,
             fixed: true,
-            highlight: false,
-            recursionDepthLow: 8,
-            recursionDepthHigh: 15
+            highlight: false
         });
 
-        this.l2 = this.board.create('functiongraph', [f2, 0, 500], {
+        this.l2 = this.board.create('functiongraph', [
+            f2, 0, this.options.gXAxisMax
+        ], {
             name: 'FC',
             withLabel: true,
             strokeWidth: 2,
             strokeColor: this.l2Color,
             fixed: true,
-            highlight: false,
-            recursionDepthLow: 8,
-            recursionDepthHigh: 15
+            highlight: false
         });
 
-        this.l3 = this.board.create('functiongraph', [f3, 0, 500], {
+        this.l3 = this.board.create('functiongraph', [
+            f3, 0, this.options.gXAxisMax
+        ], {
             name: 'VC',
             withLabel: true,
             strokeWidth: 2,
             strokeColor: this.l3Color,
             fixed: true,
-            highlight: false,
-            recursionDepthLow: 8,
-            recursionDepthHigh: 15
+            highlight: false
         });
     }
 }

--- a/media/js/src/utils.js
+++ b/media/js/src/utils.js
@@ -2,6 +2,46 @@
 
 const BOARD_WIDTH = 540;
 const BOARD_HEIGHT = 300;
+const GRID_MAJOR = [
+    {
+        face: 'line',
+        size: 5,
+        strokeColor: '#ffffff',
+    },
+    {
+        face: 'point',
+        size: 4,
+        strokeColor: '#bfbfbf',
+        strokeOpacity: 1,
+    },
+    {
+        face: 'line',
+        size: 2,
+        strokeColor: '#bfbfbf',
+        strokeOpacity: 1,
+    }
+];
+
+// In case we end up using minor grid markers
+const GRID_MINOR = [
+    {
+        face: 'line',
+        size: 0,
+        strokeColor: '#ffffff',
+    },
+    {
+        face: 'point',
+        size: 3,
+        strokeColor: '#efefef',
+        strokeOpacity: 1,
+    },
+    {
+        face: 'line',
+        size: 1,
+        strokeColor: '#efefef',
+        strokeOpacity: 1,
+    }
+];
 
 /**
  * A wrapper for `fetch` that passes along auth credentials.
@@ -399,52 +439,41 @@ const btnStep = function(val, sign, strength, min, max) {
     return forceFloat(val);
 };
 
-const GRID_MAJOR = [
-    {
-        face: 'line',
-        size: 5,
-        strokeColor: '#ffffff',
-    },
-    {
-        face: 'point',
-        size: 4,
-        strokeColor: '#bfbfbf',
-        strokeOpacity: 1,
-    },
-    {
-        face: 'line',
-        size: 2,
-        strokeColor: '#bfbfbf',
-        strokeOpacity: 1,
+/**
+ * Set defaults to the given state object based on toggle and function
+ * choice.
+ *
+ * Returns an object.
+ */
+const setDefaults = function(
+    obj, defaults, untoggledDefaults, functionChoice
+) {
+    if (Object.hasOwn(obj, 'gFunctionChoice')) {
+        Object.assign(
+            obj,
+            defaults[obj.gFunctionChoice]);
     }
-];
 
-// In case we end up using minor grid markers
-const GRID_MINOR = [
-    {
-        face: 'line',
-        size: 0,
-        strokeColor: '#ffffff',
-    },
-    {
-        face: 'point',
-        size: 3,
-        strokeColor: '#efefef',
-        strokeOpacity: 1,
-    },
-    {
-        face: 'line',
-        size: 1,
-        strokeColor: '#efefef',
-        strokeOpacity: 1,
+    if (Object.hasOwn(obj, 'gToggle')) {
+        if (obj.gToggle) {
+            Object.assign(
+                obj,
+                defaults[functionChoice]);
+        } else {
+            Object.assign(obj, untoggledDefaults);
+        }
     }
-];
+
+    return obj;
+};
 
 export {
+    BOARD_HEIGHT, BOARD_WIDTH, GRID_MAJOR, GRID_MINOR,
+
     authedFetch, getAssessment, getQuestion, getMultipleChoice, getEvaluations,
     getGraph, getGraphId, getCohortId, getTopics, getSubmission,
     getUserAssignment, createSubmission, getOrCreateSubmission,
     getL1SubmissionOffset, getL2SubmissionOffset, handleFormUpdate, getOffset,
     getXIntercept, getYIntercept, forceFloat, forceNumber, displayGraphType,
-    getError, btnStep, BOARD_HEIGHT, BOARD_WIDTH, GRID_MAJOR, GRID_MINOR
+    getError, btnStep, setDefaults
 };


### PR DESCRIPTION
My plan is to actually combine the two cost functions graph types into a single one with radio buttons. Working up to that, here are a bunch of fixes for this graph type, correcting the default scale, and also a bug in calculateBoundingBox().

I've generalized some of the defaults logic into a setDefault() function we can use for any graphs that have multiple function types or modes.