### PR TITLE
Step name: use value instead of placeholder for name input

### DIFF
--- a/econplayground/templates/assignment/assignment_step_layout.html
+++ b/econplayground/templates/assignment/assignment_step_layout.html
@@ -33,7 +33,7 @@
                     <input name="step_name"
                            class="form-control form-control-sm ep-step-name-input mb-1"
                            style="display: none;"
-                           placeholder="{% step_name step.id %}"
+                           value="{% step_name step.id %}"
                            type="text" />
 
                     {% if step.id == last_step_id %}


### PR DESCRIPTION
This input item should default to the current step name, rather than using the display-only placeholder field.