### PR TITLE
Nest MinMaxEditor inside RangeEditor

### DIFF
--- a/media/js/src/editors/CostFunctionsTotalEditor.jsx
+++ b/media/js/src/editors/CostFunctionsTotalEditor.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import RangeEditor from '../form-components/RangeEditor.jsx';
-import MinMaxEditor from '../form-components/MinMaxEditor.jsx';
 import { handleFormUpdate } from '../utils.js';
 import { getKatexEl } from '../katexUtils.jsx';
 
@@ -44,15 +43,11 @@ export default class CostFunctionsTotalEditor extends React.Component {
                             </label>
                             <RangeEditor
                                 id="gA1"
+                                name={this.props.gA1Name}
                                 value={this.props.gA1}
                                 min={this.props.gA1Min}
                                 max={this.props.gA1Max}
-                                handler={handleFormUpdate.bind(this)} />
-                            <MinMaxEditor
-                                id="gA1"
-                                label={this.props.gA1Name}
-                                min={this.props.gA1Min}
-                                max={this.props.gA1Max}
+                                showMinMaxEditor={true}
                                 handler={handleFormUpdate.bind(this)} />
                         </div>
 
@@ -74,15 +69,11 @@ export default class CostFunctionsTotalEditor extends React.Component {
                             </label>
                             <RangeEditor
                                 id="gA2"
+                                name={this.props.gA2Name}
                                 value={this.props.gA2}
                                 min={this.props.gA2Min}
                                 max={this.props.gA2Max}
-                                handler={handleFormUpdate.bind(this)} />
-                            <MinMaxEditor
-                                id="gA2"
-                                label={this.props.gA2Name}
-                                min={this.props.gA2Min}
-                                max={this.props.gA2Max}
+                                showMinMaxEditor={true}
                                 handler={handleFormUpdate.bind(this)} />
                         </div>
 
@@ -104,15 +95,11 @@ export default class CostFunctionsTotalEditor extends React.Component {
                             </label>
                             <RangeEditor
                                 id="gA3"
+                                name={this.props.gA3Name}
                                 value={this.props.gA3}
                                 min={this.props.gA3Min}
                                 max={this.props.gA3Max}
-                                handler={handleFormUpdate.bind(this)} />
-                            <MinMaxEditor
-                                id="gA3"
-                                label={this.props.gA3Name}
-                                min={this.props.gA3Min}
-                                max={this.props.gA3Max}
+                                showMinMaxEditor={true}
                                 handler={handleFormUpdate.bind(this)} />
                         </div>
 

--- a/media/js/src/form-components/MinMaxEditor.jsx
+++ b/media/js/src/form-components/MinMaxEditor.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 export default class MinMaxEditor extends React.Component {
     render() {
         return (
-            <div className="input-group w-50">
+            <div className="input-group">
                 <label
                     className="input-group-text"
                     htmlFor={this.props.id + 'Min'}>

--- a/media/js/src/form-components/RangeEditor.jsx
+++ b/media/js/src/form-components/RangeEditor.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getKatexEl } from '../katexUtils.jsx';
 import { btnStep } from '../utils.js';
+import MinMaxEditor from './MinMaxEditor.jsx';
 
 /**
  * RangeEditor is a re-usable component that creates an <input> with
@@ -71,6 +72,14 @@ export default class RangeEditor extends React.Component {
                                 </div>
                             </label>
                         </div>
+                        {this.props.showMinMaxEditor && (
+                            <MinMaxEditor
+                                id={this.props.id}
+                                label={this.props.name}
+                                min={this.props.min}
+                                max={this.props.max}
+                                handler={this.props.handler} />
+                        )}
                     </div>
                     <div className="col-5">
                         <div className="mb-2 input-group">
@@ -179,6 +188,7 @@ RangeEditor.defaultProps = {
     override2Label: '',
     override2Value: 0,
     showMinMax: false,
+    showMinMaxEditor: false,
     showValue: true,
     disabled: false
 };
@@ -186,6 +196,7 @@ RangeEditor.defaultProps = {
 RangeEditor.propTypes = {
     id: PropTypes.string.isRequired,
     handler: PropTypes.func.isRequired,
+    name: PropTypes.string,
     value: PropTypes.number.isRequired,
     step: PropTypes.number,
     min: PropTypes.number,
@@ -202,6 +213,7 @@ RangeEditor.propTypes = {
     override2Label: PropTypes.string,
     override2Value: PropTypes.number,
     showMinMax: PropTypes.bool,
+    showMinMaxEditor: PropTypes.bool,
     note: PropTypes.string,
     showNote: PropTypes.bool,
     showValue: PropTypes.bool,


### PR DESCRIPTION
This component should be rendered within the range input's column, so it's easiest to just put it within RangeEditor for now.

![Screenshot_2024-08-08_15-28-45](https://github.com/user-attachments/assets/a09e3f67-c2d8-4b81-bf7c-c5ede5100417)
