### PR TITLE
RangeEditor: migrate from dataId to id

### DIFF
--- a/media/js/src/editors/ADASEditor.jsx
+++ b/media/js/src/editors/ADASEditor.jsx
@@ -48,7 +48,7 @@ export default class ADASEditor extends React.Component {
                         <h3>Slope</h3>
                         <RangeEditor
                             label="\text{Orange line slope}"
-                            dataId="gLine1Slope"
+                            id="gLine1Slope"
                             value={this.props.gLine1Slope}
                             min={0}
                             max={5}
@@ -61,7 +61,7 @@ export default class ADASEditor extends React.Component {
                             handler={handleFormUpdate.bind(this)} />
                         <RangeEditor
                             label="\text{Blue line slope}"
-                            dataId="gLine2Slope"
+                            id="gLine2Slope"
                             min={-5}
                             max={0}
                             value={this.props.gLine2Slope}
@@ -74,7 +74,7 @@ export default class ADASEditor extends React.Component {
                             handler={handleFormUpdate.bind(this)} />
                         <RangeEditor
                             label="\text{Red line slope}"
-                            dataId="gLine3Slope"
+                            id="gLine3Slope"
                             value={this.props.gLine3Slope}
                             min={-5}
                             max={5}

--- a/media/js/src/editors/CobbDouglasEditor.jsx
+++ b/media/js/src/editors/CobbDouglasEditor.jsx
@@ -60,7 +60,7 @@ export default class CobbDouglasEditor extends React.Component {
                             )}
                         </label>
                         <RangeEditor
-                            dataId="gA1"
+                            id="gA1"
                             value={this.props.gA1}
                             handler={handleFormUpdate.bind(this)}
                             min={0} />
@@ -79,13 +79,13 @@ export default class CobbDouglasEditor extends React.Component {
                             )}
                         </label>
                         <RangeEditor
-                            dataId="gA3"
+                            id="gA3"
                             value={this.props.gA3}
                             handler={handleFormUpdate.bind(this)}
                             min={0} />
                         <RangeEditor
                             label="\alpha"
-                            dataId="gA4"
+                            id="gA4"
                             value={this.props.gA4}
                             handler={handleFormUpdate.bind(this)}
                             min={0}
@@ -107,7 +107,7 @@ export default class CobbDouglasEditor extends React.Component {
                             )}
                         </label>
                         <RangeEditor
-                            dataId="gA2"
+                            id="gA2"
                             value={this.props.gA2}
                             handler={handleFormUpdate.bind(this)}
                             min={0}

--- a/media/js/src/editors/CobbDouglasNLDSEditor.jsx
+++ b/media/js/src/editors/CobbDouglasNLDSEditor.jsx
@@ -105,7 +105,7 @@ export default class CobbDouglasNLDSEditor extends React.Component {
                                 )}
                             </label>
                             <RangeEditor
-                                dataId="gCobbDouglasA"
+                                id="gCobbDouglasA"
                                 value={this.props.gCobbDouglasA}
                                 handler={handleFormUpdate.bind(this)}
                                 min={0} />
@@ -124,13 +124,13 @@ export default class CobbDouglasNLDSEditor extends React.Component {
                                 )}
                             </label>
                             <RangeEditor
-                                dataId="gCobbDouglasK"
+                                id="gCobbDouglasK"
                                 value={this.props.gCobbDouglasK}
                                 handler={handleFormUpdate.bind(this)}
                                 min={0} />
                             <RangeEditor
                                 label="\alpha"
-                                dataId="gCobbDouglasAlpha"
+                                id="gCobbDouglasAlpha"
                                 value={this.props.gCobbDouglasAlpha}
                                 handler={handleFormUpdate.bind(this)}
                                 min={0}
@@ -152,14 +152,14 @@ export default class CobbDouglasNLDSEditor extends React.Component {
                                 )}
                             </label>
                             <RangeEditor
-                                dataId="gCobbDouglasL"
+                                id="gCobbDouglasL"
                                 value={this.props.gCobbDouglasL}
                                 handler={handleFormUpdate.bind(this)}
                                 min={0}
                                 max={10} />
                             <RangeEditor
                                 label="\text{Orange line slope}"
-                                dataId="gLine1Slope"
+                                id="gLine1Slope"
                                 value={this.props.gLine1Slope}
                                 min={0}
                                 showOverrideButton={true}

--- a/media/js/src/editors/ConsumptionLeisureEditor.jsx
+++ b/media/js/src/editors/ConsumptionLeisureEditor.jsx
@@ -34,7 +34,6 @@ export default class ConsumptionLeisureEditor extends React.Component {
                         <RangeEditor
                             label="\text{Horizontal intercept value: }T"
                             id="gA1"
-                            dataId="gA1"
                             value={this.props.gA1}
                             min={0}
                             max={9}
@@ -42,7 +41,6 @@ export default class ConsumptionLeisureEditor extends React.Component {
                         <RangeEditor
                             label="\text{Real Wage: }w"
                             id="gA2"
-                            dataId="gA2"
                             value={this.props.gA2}
                             min={0}
                             max={5}
@@ -51,7 +49,6 @@ export default class ConsumptionLeisureEditor extends React.Component {
                             <RangeEditor
                                 label="\text{Rel. Preference: }\alpha"
                                 id="gA3"
-                                dataId="gA3"
                                 value={this.props.gA3}
                                 min={0}
                                 max={0.99999}
@@ -60,7 +57,6 @@ export default class ConsumptionLeisureEditor extends React.Component {
                         <RangeEditor
                             label="\text{Tax Rate: }t"
                             id="gA4"
-                            dataId="gA4"
                             value={this.props.gA4}
                             min={0}
                             max={0.99999}

--- a/media/js/src/editors/ConsumptionSavingEditor.jsx
+++ b/media/js/src/editors/ConsumptionSavingEditor.jsx
@@ -38,7 +38,6 @@ export default class ConsumptionSavingEditor extends React.Component {
                         <RangeEditor
                             label="y_1"
                             id="gA1"
-                            dataId="gA1"
                             value={this.props.gA1}
                             min={0}
                             max={5}
@@ -46,7 +45,6 @@ export default class ConsumptionSavingEditor extends React.Component {
                         <RangeEditor
                             label="y_2"
                             id="gA2"
-                            dataId="gA2"
                             value={this.props.gA2}
                             min={0}
                             max={5}
@@ -54,7 +52,6 @@ export default class ConsumptionSavingEditor extends React.Component {
                         <RangeEditor
                             label="W"
                             id="gA3"
-                            dataId="gA3"
                             value={this.props.gA3}
                             min={-5}
                             max={5}
@@ -62,7 +59,6 @@ export default class ConsumptionSavingEditor extends React.Component {
                         <RangeEditor
                             label="r"
                             id="gA4"
-                            dataId="gA4"
                             value={this.props.gA4}
                             min={-1}
                             max={10}
@@ -71,7 +67,6 @@ export default class ConsumptionSavingEditor extends React.Component {
                             <RangeEditor
                                 label="\beta"
                                 id="gA5"
-                                dataId="gA5"
                                 value={this.props.gA5}
                                 min={0}
                                 max={1}

--- a/media/js/src/editors/CostFunctionsUnitEditor.jsx
+++ b/media/js/src/editors/CostFunctionsUnitEditor.jsx
@@ -84,7 +84,6 @@ export default class CostFunctionsUnitEditor extends React.Component {
                                     key={key}
                                     label={i[1]}
                                     id={i[0]}
-                                    dataId={i[0]}
                                     value={this.props[i[0]]}
                                     min={this.props[i[0] + 'Min']}
                                     max={this.props[i[0] + 'Max']}

--- a/media/js/src/editors/DemandSupplyEditor.jsx
+++ b/media/js/src/editors/DemandSupplyEditor.jsx
@@ -37,7 +37,7 @@ export default class DemandSupplyEditor extends React.Component {
                     <h3>Slope</h3>
                     <RangeEditor
                         label="\text{Orange line slope}"
-                        dataId="gLine1Slope"
+                        id="gLine1Slope"
                         value={this.props.gLine1Slope}
                         min={0}
                         max={5}
@@ -51,7 +51,7 @@ export default class DemandSupplyEditor extends React.Component {
                         handler={handleFormUpdate.bind(this)} />
                     <RangeEditor
                         label="\text{Blue line slope}"
-                        dataId="gLine2Slope"
+                        id="gLine2Slope"
                         min={-5}
                         max={0}
                         value={this.props.gLine2Slope}
@@ -67,7 +67,7 @@ export default class DemandSupplyEditor extends React.Component {
                         <>
                             <RangeEditor
                                 label="\text{Right graph: Orange line slope}"
-                                dataId="gLine3Slope"
+                                id="gLine3Slope"
                                 value={this.props.gLine3Slope}
                                 min={0}
                                 max={5}
@@ -81,7 +81,7 @@ export default class DemandSupplyEditor extends React.Component {
                                 handler={handleFormUpdate.bind(this)} />
                             <RangeEditor
                                 label="\text{Right graph: Blue line slope}"
-                                dataId="gLine4Slope"
+                                id="gLine4Slope"
                                 min={-5}
                                 max={0}
                                 value={this.props.gLine4Slope}

--- a/media/js/src/editors/NonLinearDemandSupplyEditor.jsx
+++ b/media/js/src/editors/NonLinearDemandSupplyEditor.jsx
@@ -51,7 +51,7 @@ export default class NonLinearDemandSupplyEditor extends React.Component {
                             <h3>Slope</h3>
                             <RangeEditor
                                 label="\text{Orange line slope}"
-                                dataId="gLine1Slope"
+                                id="gLine1Slope"
                                 value={this.props.gLine1Slope}
                                 showOverrideButton={true}
                                 overrideLabel='Vertical'
@@ -76,7 +76,7 @@ export default class NonLinearDemandSupplyEditor extends React.Component {
                                 )}
                             </label>
                             <RangeEditor
-                                dataId="gCobbDouglasA"
+                                id="gCobbDouglasA"
                                 value={this.props.gCobbDouglasA}
                                 handler={handleFormUpdate.bind(this)}
                                 step={0.1}
@@ -96,7 +96,7 @@ export default class NonLinearDemandSupplyEditor extends React.Component {
                                 ) : this.props.gCobbDouglasKName)}
                             </label>
                             <RangeEditor
-                                dataId="gCobbDouglasK"
+                                id="gCobbDouglasK"
                                 value={this.props.gCobbDouglasK}
                                 handler={handleFormUpdate.bind(this)}
                                 min={0}

--- a/media/js/src/editors/OptimalChoiceConsumption.jsx
+++ b/media/js/src/editors/OptimalChoiceConsumption.jsx
@@ -70,7 +70,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="\alpha"
                         id="gA4"
-                        dataId="gA4"
                         value={this.props.gA4}
                         min={0.01}
                         max={5}
@@ -79,7 +78,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="\beta"
                         id="gA5"
-                        dataId="gA5"
                         value={this.props.gA5}
                         min={0.01}
                         max={5}
@@ -89,7 +87,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="\alpha"
                         id="gA4"
-                        dataId="gA4"
                         value={this.props.gA4}
                         min={0.01}
                         max={0.99}
@@ -99,7 +96,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="\rho"
                         id="gA4"
-                        dataId="gA4"
                         value={this.props.gA4}
                         min={-10}
                         max={0.99}
@@ -109,7 +105,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="\delta"
                         id="gA4"
-                        dataId="gA4"
                         value={this.props.gA4}
                         min={-10}
                         max={0.99}
@@ -120,7 +115,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="a"
                         id="gA4"
-                        dataId="gA4"
                         value={this.props.gA4}
                         min={0}
                         max={25}
@@ -129,7 +123,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="b"
                         id="gA5"
-                        dataId="gA5"
                         value={this.props.gA5}
                         min={0}
                         max={25}
@@ -139,7 +132,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="a"
                         id="gA4"
-                        dataId="gA4"
                         value={this.props.gA4}
                         min={0.01}
                         max={25}
@@ -148,7 +140,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="b"
                         id="gA5"
-                        dataId="gA5"
                         value={this.props.gA5}
                         min={0.01}
                         max={25}
@@ -158,7 +149,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="a"
                         id="gA4"
-                        dataId="gA4"
                         value={this.props.gA4}
                         min={0}
                         max={500}
@@ -167,7 +157,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                     <RangeEditor
                         label="b"
                         id="gA5"
-                        dataId="gA5"
                         value={this.props.gA5}
                         min={0.01}
                         max={25}
@@ -206,7 +195,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                         <RangeEditor
                             label="px"
                             id="gA1"
-                            dataId="gA1"
                             value={this.props.gA1}
                             min={0}
                             max={30}
@@ -215,7 +203,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                         <RangeEditor
                             label="py"
                             id="gA2"
-                            dataId="gA2"
                             value={this.props.gA2}
                             min={0.01}
                             max={30}
@@ -224,7 +211,6 @@ export default class OptimalChoiceConsumptionEditor extends React.Component {
                         <RangeEditor
                             label="R"
                             id="gA3"
-                            dataId="gA3"
                             value={this.props.gA3}
                             min={0}
                             max={5000}

--- a/media/js/src/editors/OptimalChoiceCostMinimizingEditor.jsx
+++ b/media/js/src/editors/OptimalChoiceCostMinimizingEditor.jsx
@@ -57,7 +57,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                             <RangeEditor
                                 label="w"
                                 id="gA1"
-                                dataId="gA1"
                                 value={this.props.gA1}
                                 min={0}
                                 max={30}
@@ -66,7 +65,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                             <RangeEditor
                                 label="r"
                                 id="gA2"
-                                dataId="gA2"
                                 value={this.props.gA2}
                                 min={0.01}
                                 max={30}
@@ -75,7 +73,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                             <RangeEditor
                                 label={this.props.gToggle ? 'q' : 'c'}
                                 id="gA3"
-                                dataId="gA3"
                                 value={this.props.gA3}
                                 min={0}
                                 max={5000}
@@ -86,7 +83,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\alpha"
                                         id="gA4"
-                                        dataId="gA4"
                                         value={this.props.gA4}
                                         min={0.01}
                                         max={1}
@@ -94,7 +90,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\beta"
                                         id="gA5"
-                                        dataId="gA5"
                                         value={this.props.gA5}
                                         min={0.01}
                                         max={1}
@@ -107,7 +102,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\alpha"
                                         id="gA4"
-                                        dataId="gA4"
                                         value={this.props.gA4}
                                         min={0.01}
                                         max={1}
@@ -120,7 +114,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\alpha"
                                         id="gA4"
-                                        dataId="gA4"
                                         value={this.props.gA4}
                                         min={0}
                                         max={2}
@@ -129,7 +122,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\text{Input Tax Rate, }t"
                                         id="gA5"
-                                        dataId="gA5"
                                         value={this.props.gA5}
                                         min={0}
                                         max={2}
@@ -138,7 +130,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\text{Labor Tax Rate, }t_w"
                                         id="gA6"
-                                        dataId="gA6"
                                         value={this.props.gA6}
                                         min={0}
                                         max={2}
@@ -147,7 +138,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\text{Capital Tax Rate, }t_r"
                                         id="gA7"
-                                        dataId="gA7"
                                         value={this.props.gA7}
                                         min={0}
                                         max={2}
@@ -156,7 +146,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\text{Business License, }f"
                                         id="gA8"
-                                        dataId="gA8"
                                         value={this.props.gA8}
                                         min={0}
                                         max={2}
@@ -169,7 +158,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="\rho"
                                         id="gA4"
-                                        dataId="gA4"
                                         value={this.props.gA4}
                                         min={0.01}
                                         max={1}
@@ -185,7 +173,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="a"
                                         id="gA4"
-                                        dataId="gA4"
                                         value={this.props.gA4}
                                         min={0}
                                         max={25}
@@ -193,7 +180,6 @@ export default class OptimalChoiceCostMinimizingEditor extends React.Component {
                                     <RangeEditor
                                         label="b"
                                         id="gA5"
-                                        dataId="gA5"
                                         value={this.props.gA5}
                                         min={0}
                                         max={25}

--- a/media/js/src/editors/RevenueElasticityEditor.jsx
+++ b/media/js/src/editors/RevenueElasticityEditor.jsx
@@ -68,7 +68,6 @@ export default class RevenueElasticityEditor extends React.Component {
                                     className="col-6"
                                     id={i[0]}
                                     label={i[1]}
-                                    dataId={i[0]}
                                     min={this.props[i[0] + 'Min']}
                                     max={this.props[i[0] + 'Max']}
                                     handler={handleFormUpdate.bind(this)}/>
@@ -84,7 +83,6 @@ export default class RevenueElasticityEditor extends React.Component {
                                     key={key}
                                     label={i[1]}
                                     id={i[0]}
-                                    dataId={i[0]}
                                     value={this.props[i[0]]}
                                     min={this.props[i[0] + 'Min']}
                                     max={this.props[i[0] + 'Max']}

--- a/media/js/src/editors/TaxRevenueEditor.jsx
+++ b/media/js/src/editors/TaxRevenueEditor.jsx
@@ -130,7 +130,6 @@ export default class TaxRevenueEditor extends React.Component {
                                     id={i[0]}
                                     label={i[1]}
                                     rawLabel={true}
-                                    dataId={i[0]}
                                     min={this.props[i[0] + 'Min' + eqNum]}
                                     max={this.props[i[0] + 'Max' + eqNum]}
                                     handler={handleFormUpdate.bind(this)}/>
@@ -143,7 +142,6 @@ export default class TaxRevenueEditor extends React.Component {
                                 id={'gA5' + eqNum}
                                 label={'Unit Tax'}
                                 rawLabel={true}
-                                dataId={'gA5' + eqNum}
                                 min={this.props['gA5Min' + eqNum]}
                                 max={this.props['gA5Max' + eqNum]}
                                 handler={handleFormUpdate.bind(this)}/>
@@ -164,7 +162,6 @@ export default class TaxRevenueEditor extends React.Component {
                                     label={i[1]}
                                     rawLabel={true}
                                     id={i[0] + eqNum}
-                                    dataId={i[0] + eqNum}
                                     value={this.props[i[0] + eqNum]}
                                     min={this.props[i[0] + 'Min' + eqNum]}
                                     max={this.props[i[0] + 'Max' + eqNum]}
@@ -178,7 +175,6 @@ export default class TaxRevenueEditor extends React.Component {
                                 label={'Unit Tax'}
                                 rawLabel={true}
                                 id={'gA5' + eqNum}
-                                dataId={'gA5' + eqNum}
                                 value={this.props['gA5' + eqNum]}
                                 min={this.props['gA5Min' + eqNum]}
                                 max={this.props['gA5Max' + eqNum]}

--- a/media/js/src/editors/TaxationLinearDemandEditor.jsx
+++ b/media/js/src/editors/TaxationLinearDemandEditor.jsx
@@ -51,7 +51,6 @@ export default class TaxationLinearDemandEditor extends React.Component {
                     label="Choke Price"
                     rawLabel={true}
                     id="gA1"
-                    dataId="gA1"
                     value={this.props.gA1}
                     min={0}
                     max={10000}
@@ -61,7 +60,6 @@ export default class TaxationLinearDemandEditor extends React.Component {
                     label="Demand Slope"
                     rawLabel={true}
                     id="gLine2Slope"
-                    dataId="gLine2Slope"
                     value={this.props.gLine2Slope}
                     min={0.01}
                     max={35}
@@ -71,7 +69,6 @@ export default class TaxationLinearDemandEditor extends React.Component {
                     label="Reservation Price"
                     rawLabel={true}
                     id="gA2"
-                    dataId="gA2"
                     value={this.props.gA2}
                     min={0}
                     max={10000}
@@ -81,7 +78,6 @@ export default class TaxationLinearDemandEditor extends React.Component {
                     label="Supply Slope"
                     rawLabel={true}
                     id="gLine1Slope"
-                    dataId="gLine1Slope"
                     value={this.props.gLine1Slope}
                     min={0.01}
                     max={35}
@@ -92,7 +88,6 @@ export default class TaxationLinearDemandEditor extends React.Component {
                         label="Unit Tax"
                         rawLabel={true}
                         id="gA3"
-                        dataId="gA3"
                         value={this.props.gA3}
                         min={0}
                         max={1500}
@@ -104,7 +99,6 @@ export default class TaxationLinearDemandEditor extends React.Component {
                         label="Tax Rate"
                         rawLabel={true}
                         id="gA3"
-                        dataId="gA3"
                         value={this.props.gA3}
                         min={0}
                         max={2}


### PR DESCRIPTION
This element's `id` and `data-id` is always going to be either the same, or both based on `id`, so dataId can be removed.