### PR TITLE
DefineRange: remove dataId from required props

### DIFF
--- a/media/js/src/form-components/DefineRange.jsx
+++ b/media/js/src/form-components/DefineRange.jsx
@@ -59,8 +59,7 @@ DefineRange.defaultProps = {
 };
 
 DefineRange.propTypes = {
-    id: PropTypes.string,
-    dataId: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
     handler: PropTypes.func.isRequired,
     min: PropTypes.number,
     max: PropTypes.number,


### PR DESCRIPTION
The id is now required, rather than the dataId.