### PR TITLE
Add configurable labels and line color legend to Cost Functions

### DIFF
--- a/media/js/src/JXGBoard.jsx
+++ b/media/js/src/JXGBoard.jsx
@@ -5,11 +5,15 @@ import PropTypes from 'prop-types';
 
 import JXG from 'jsxgraph';
 import { getKatexEl } from './katexUtils.jsx';
+import {
+    LINE_1_COLOR, LINE_2_COLOR, LINE_3_COLOR, LINE_4_COLOR
+} from './graphs/Graph.js';
 import { graphTypes, isJointGraph } from './graphs/graphTypes.js';
 import { mkNonLinearDemandSupply } from './graphs/NonLinearDemandSupplyGraph.js';
 import { mkDemandSupply } from './graphs/DemandSupplyGraph.js';
 import { mkTaxationLinearDemandSupply } from './graphs/TaxationLinearDemandSupplyGraph.js';
 import AreaDisplay from './AreaDisplay.jsx';
+import Legend from './Legend.jsx';
 import {
     getL1SubmissionOffset, getL2SubmissionOffset, GRID_MAJOR, GRID_MINOR
 } from './utils.js';
@@ -705,7 +709,11 @@ export default class JXGBoard extends React.Component {
     // called only if shouldComponentUpdate returns true
     // for rendering the JSXGraph board div and any child elements
     render() {
-        let math1 = null, math2 = null, area = null, figure2 = true;
+        let math1 = null;
+        let math2 = null;
+        let area = null;
+        let figure2 = true;
+
         if (this.props.gType === 9 || this.props.gType === 10) {
             area = <AreaDisplay
                 areaConf={this.props.gAreaConfiguration}
@@ -722,10 +730,28 @@ export default class JXGBoard extends React.Component {
             }
             figure2 = false;
         }
+
+        let legend = null;
+        if (this.props.gType === 18) {
+            legend = (
+                <Legend
+                    gLine1Label={this.props.gLine1Label}
+                    line1Color={LINE_1_COLOR}
+                    gLine2Label={this.props.gLine2Label}
+                    line2Color={LINE_2_COLOR}
+                    gLine3Label={this.props.gLine3Label}
+                    line3Color={LINE_3_COLOR}
+                    gLine4Label={this.props.gLine4Label}
+                    line4Color={LINE_4_COLOR}
+                />
+            );
+        }
+
         return (
             <>
                 {this.makeFigure(this.id, false, math1)}
                 {this.makeFigure(this.id + '-2', figure2, math2)}
+                {legend}
                 {area}
             </>
         );

--- a/media/js/src/Legend.jsx
+++ b/media/js/src/Legend.jsx
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const displayColor = function(label, color, idx) {
+    return (
+        <span className="me-2" key={idx}>
+            {label}: <i style={{color: color}} className="bi bi-circle-fill"></i>
+        </span>
+    );
+};
+
+export default class Legend extends Component {
+    static propTypes = {
+        gLine1Label: PropTypes.string,
+        line1Color: PropTypes.string,
+
+        gLine2Label: PropTypes.string,
+        line2Color: PropTypes.string,
+
+        gLine3Label: PropTypes.string,
+        line3Color: PropTypes.string,
+
+        gLine4Label: PropTypes.string,
+        line4Color: PropTypes.string
+    };
+
+    render() {
+        const elements = [];
+
+        if (this.props.gLine1Label && this.props.line1Color) {
+            elements.push(
+                displayColor(this.props.gLine1Label, this.props.line1Color, 1)
+            );
+        }
+
+        if (this.props.gLine2Label && this.props.line2Color) {
+            elements.push(
+                displayColor(this.props.gLine2Label, this.props.line2Color, 2)
+            );
+        }
+
+        if (this.props.gLine3Label && this.props.line3Color) {
+            elements.push(
+                displayColor(this.props.gLine3Label, this.props.line3Color, 3)
+            );
+        }
+
+        if (this.props.gLine4Label && this.props.line4Color) {
+            elements.push(
+                displayColor(this.props.gLine4Label, this.props.line4Color, 4)
+            );
+        }
+
+        return elements;
+    }
+}

--- a/media/js/src/editors/CostFunctionsEditor.jsx
+++ b/media/js/src/editors/CostFunctionsEditor.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import EditableControl from '../form-components/EditableControl.jsx';
 import RangeEditor from '../form-components/RangeEditor.jsx';
 import { handleFormUpdate } from '../utils.js';
 import { getKatexEl } from '../katexUtils.jsx';
@@ -125,7 +126,74 @@ export default class CostFunctionsEditor extends React.Component {
 
                     </React.Fragment>
                 )}
-            </div >
+                {this.props.displayLabels && (
+                    <>
+                        <h3>Labels</h3>
+                        <div className="d-flex flex-wrap">
+                            <div className="row">
+                                <div className="col">
+                                    <EditableControl
+                                        id="gLine1Label"
+                                        name="Orange line label"
+                                        value={this.props.gLine1Label}
+                                        valueEditable={true}
+                                        isInstructor={true}
+                                        updateGraph={this.props.updateGraph} />
+                                </div>
+                                <div className="col">
+                                    <EditableControl
+                                        id="gLine2Label"
+                                        name="Blue line label"
+                                        value={this.props.gLine2Label}
+                                        valueEditable={true}
+                                        isInstructor={true}
+                                        updateGraph={this.props.updateGraph} />
+                                </div>
+                                <div className="col">
+                                    <EditableControl
+                                        id="gLine3Label"
+                                        name="Red line label"
+                                        value={this.props.gLine3Label}
+                                        valueEditable={true}
+                                        isInstructor={true}
+                                        updateGraph={this.props.updateGraph} />
+                                </div>
+                                {this.props.gFunctionChoice === 1 && (
+                                    <div className="col">
+                                        <EditableControl
+                                            id="gLine4Label"
+                                            name="Green line label"
+                                            value={this.props.gLine4Label}
+                                            valueEditable={true}
+                                            isInstructor={true}
+                                            updateGraph={this.props.updateGraph} />
+                                    </div>
+                                )}
+                            </div>
+                            <div className="row">
+                                <div className="col">
+                                    <EditableControl
+                                        id="gXAxisLabel"
+                                        name="X-axis label"
+                                        value={this.props.gXAxisLabel}
+                                        valueEditable={true}
+                                        isInstructor={true}
+                                        updateGraph={this.props.updateGraph} />
+                                </div>
+                                <div className="col">
+                                    <EditableControl
+                                        id="gYAxisLabel"
+                                        name="Y-axis label"
+                                        value={this.props.gYAxisLabel}
+                                        valueEditable={true}
+                                        isInstructor={true}
+                                        updateGraph={this.props.updateGraph} />
+                                </div>
+                            </div>
+                        </div>
+                    </>
+                )}
+            </div>
         );
     }
 }
@@ -145,6 +213,15 @@ CostFunctionsEditor.propTypes = {
     gA3Name: PropTypes.string.isRequired,
     gA3Min: PropTypes.number.isRequired,
     gA3Max: PropTypes.number.isRequired,
+
+    displayLabels: PropTypes.bool.isRequired,
+    gLine1Label: PropTypes.string.isRequired,
+    gLine2Label: PropTypes.string.isRequired,
+    gLine3Label: PropTypes.string.isRequired,
+    gLine4Label: PropTypes.string.isRequired,
+
+    gXAxisLabel: PropTypes.string.isRequired,
+    gYAxisLabel: PropTypes.string.isRequired,
 
     gFunctionChoice: PropTypes.number.isRequired,
 

--- a/media/js/src/graphs/CostFunctionsGraph.js
+++ b/media/js/src/graphs/CostFunctionsGraph.js
@@ -2,6 +2,9 @@ import {Graph} from './Graph.js';
 
 export const defaults = [
     {
+        gLine1Label: 'TC',
+        gLine2Label: 'VC',
+        gLine3Label: 'FC',
         gA1: 4000,
         gA1Name: 'a',
         gA1Min: 0,
@@ -18,6 +21,10 @@ export const defaults = [
         gYAxisMax: 10000
     },
     {
+        gLine1Label: 'MC',
+        gLine2Label: 'AC',
+        gLine3Label: 'AFC',
+        gLine4Label: 'AVC',
         gA1: 2000,
         gA1Name: 'a',
         gA1Min: 0,
@@ -85,8 +92,11 @@ export class CostFunctionsGraph extends Graph {
             this.l1 = this.board.create('functiongraph', [
                 f1, 0, this.options.gXAxisMax
             ], {
-                name: 'TC',
+                name: this.options.gLine1Label,
                 withLabel: true,
+                label: {
+                    autoPosition: true
+                },
                 strokeWidth: 2,
                 strokeColor: this.l1Color,
                 fixed: true,
@@ -96,8 +106,11 @@ export class CostFunctionsGraph extends Graph {
             this.l2 = this.board.create('functiongraph', [
                 f2, 0, this.options.gXAxisMax
             ], {
-                name: 'FC',
+                name: this.options.gLine2Label,
                 withLabel: true,
+                label: {
+                    autoPosition: true
+                },
                 strokeWidth: 2,
                 strokeColor: this.l2Color,
                 fixed: true,
@@ -107,8 +120,11 @@ export class CostFunctionsGraph extends Graph {
             this.l3 = this.board.create('functiongraph', [
                 f3, 0, this.options.gXAxisMax
             ], {
-                name: 'VC',
+                name: this.options.gLine3Label,
                 withLabel: true,
+                label: {
+                    autoPosition: true
+                },
                 strokeWidth: 2,
                 strokeColor: this.l3Color,
                 fixed: true,
@@ -134,8 +150,11 @@ export class CostFunctionsGraph extends Graph {
             this.l1 = this.board.create('functiongraph', [
                 f1, 0, this.options.gXAxisMax
             ], {
-                name: 'MC',
+                name: this.options.gLine1Label,
                 withLabel: true,
+                label: {
+                    autoPosition: true
+                },
                 strokeWidth: 2,
                 strokeColor: this.l1Color,
                 fixed: true,
@@ -145,7 +164,7 @@ export class CostFunctionsGraph extends Graph {
             this.l2 = this.board.create('functiongraph', [
                 f2, 0, this.options.gXAxisMax
             ], {
-                name: 'AC',
+                name: this.options.gLine2Label,
                 withLabel: true,
                 strokeWidth: 2,
                 strokeColor: this.l2Color,
@@ -156,8 +175,11 @@ export class CostFunctionsGraph extends Graph {
             this.l3 = this.board.create('functiongraph', [
                 f3, 0, this.options.gXAxisMax
             ], {
-                name: 'AFC',
+                name: this.options.gLine3Label,
                 withLabel: true,
+                label: {
+                    autoPosition: true
+                },
                 strokeWidth: 2,
                 strokeColor: this.l3Color,
                 fixed: true,
@@ -167,8 +189,11 @@ export class CostFunctionsGraph extends Graph {
             this.l4 = this.board.create('functiongraph', [
                 f4, 0, this.options.gXAxisMax
             ], {
-                name: 'AVC',
+                name: this.options.gLine4Label,
                 withLabel: true,
+                label: {
+                    autoPosition: true
+                },
                 strokeWidth: 2,
                 strokeColor: this.l4Color,
                 fixed: true,

--- a/media/js/src/graphs/Graph.js
+++ b/media/js/src/graphs/Graph.js
@@ -2,6 +2,10 @@ import { defaultGraph } from '../GraphMapping.js';
 import {getOffset} from '../utils.js';
 import {drawPolygon} from '../jsxgraphUtils.js';
 
+export const LINE_1_COLOR = 'rgb(255, 127, 14)';
+export const LINE_2_COLOR = 'steelblue';
+export const LINE_3_COLOR = 'rgb(228, 87, 86)';
+export const LINE_4_COLOR = 'rgb(87, 200, 86)';
 
 const applyDefaults = function(obj, defaults) {
     let o = {};
@@ -102,12 +106,13 @@ export class Graph {
 
         // Line 1 and line 2
         this.l1 = null;
-        this.l1Color = 'rgb(255, 127, 14)';
+        this.l1Color = LINE_1_COLOR;
         this.l2 = null;
-        this.l2Color = 'steelblue';
+        this.l2Color = LINE_2_COLOR;
         this.l3 = null;
-        this.l3Color = 'rgb(228, 87, 86)';
-        this.l4Color = 'rgb(87, 200, 86)';
+        this.l3Color = LINE_3_COLOR;
+        this.l4Color = LINE_4_COLOR;
+
         this.shadowColor = 'rgb(200, 200, 200)';
         this.shadowAreaColor = 'rgb(150, 150, 150)';
 


### PR DESCRIPTION
JSXGraph's auto-positioned labels don't always make for a legible label position. We should probably have a legend like this as a more reliable place for this sort of thing in certain cases.

![Screenshot_2024-08-10_13-17-38](https://github.com/user-attachments/assets/6fdd28ff-a40f-4c2e-ab29-9b868af8690e)
