### PR TITLE
Simplify action evaluation

### DIFF
--- a/econplayground/assignment/views.py
+++ b/econplayground/assignment/views.py
@@ -405,7 +405,7 @@ class StepDetailView(LoginRequiredMixin, DetailView):
             if request.POST.get(field):
                 action_name = field
                 action_value = request.POST.get(field)
-                actions[action_name] = action_value
+                actions.append((action_name, action_value))
 
         return actions
 
@@ -461,19 +461,19 @@ class StepDetailView(LoginRequiredMixin, DetailView):
 
         question = step.question
 
-        actions = {}
+        actions = []
         action_name = request.POST.get('action_name')
         action_value = request.POST.get('action_value')
-        if action_name and len(action_name) > 0:
-            actions[action_name] = action_value
+        actions.append((action_name, action_value))
 
         actions = self.append_graph_form_fields(request, actions)
 
         if question:
             # Check all actions for a success.
-            results = question.evaluate_action(actions)
-            results += self.evaluate_mc(request)
-            result = all(results)
+            results = [
+                question.evaluate_action(x[0], x[1]) for x in actions if x
+            ]
+            result = any(results)
 
             # Store the result in the user's session.
             step_name = 'step_{}_{}'.format(step.assignment.pk, step.pk)
@@ -483,6 +483,7 @@ class StepDetailView(LoginRequiredMixin, DetailView):
             step_result, _ = StepResult.objects.get_or_create(
                 step=step, student=request.user)
             step_result.result = result
+
             # Check for loops
             if step.next_step and step.next_step.path < step.path:
                 step_result.loop = step_result.loop + 1


### PR DESCRIPTION
These methods were changed here to apparently improve multiple choice evaluation: (e3c57b7b941dc6e4a55aec1272d692a405bde812)

But the multiple choice feature should be compatible with our simple action evaluation system - I am in the middle of improving things there.

These methods should handle a single user action - if we want to handle multiple actions in one step we can make a new method called evaluate_actions() which makes use of the existing logic for a single action.