### PR TITLE
Taxation graph: add export

### DIFF
--- a/media/js/src/graphs/TaxationLinearDemandSupplyGraph.js
+++ b/media/js/src/graphs/TaxationLinearDemandSupplyGraph.js
@@ -57,7 +57,7 @@ export const taxar = function(c, b, a, d, t) {
     return eqat(c, b, a, d, t) * t;
 };
 
-class TaxationLinearDemandSupplyGraph extends Graph {
+export class TaxationLinearDemandSupplyGraph extends Graph {
     make() {
         const me = this;
 


### PR DESCRIPTION
This should fix the jenkins error:
```
ERROR in ./media/js/src/graphs/graphTypes.js 42:209-240
export 'TaxationLinearDemandSupplyGraph' (imported as 'TaxationLinearDemandSupplyGraph') was not found in './TaxationLinearDemandSupplyGraph.js'
```