### PR TITLE
Fix button formatting on question preview page

### DIFF
--- a/econplayground/assignment/views.py
+++ b/econplayground/assignment/views.py
@@ -724,12 +724,15 @@ class QuestionPreView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
 
+        assignment = get_object_or_404(Assignment, pk=self.assignment_pk)
+
         if self.object:
             multiple_choice = self.object.multiplechoice_set.all()
         else:
             multiple_choice = []
 
         ctx.update({
+            'assignment': assignment,
             'assignment_pk': self.kwargs.get('assignment_pk'),
             'multiple_choice': multiple_choice,
         })

--- a/econplayground/templates/assignment/assignment_question_preview.html
+++ b/econplayground/templates/assignment/assignment_question_preview.html
@@ -1,32 +1,41 @@
 {% extends 'base.html' %}
 {% load static econ_auth %}
 
-{% block title %}Preview: {{ object.title }} | EconPractice{% endblock %}
+{% block title %}Preview: {{ object }} | EconPractice{% endblock %}
 
 {% block css %}
     <link rel="stylesheet" href="{% static 'css/loaders.min.css' %}">
 {% endblock %}
 
 {% block breadcrumb %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item">
+            <a href="{% url 'assignment_list' %}" title="Assignment List">
+                {% include 'main/your_assignments_snippet.html' %}
+            </a>
+        </li>
+        <li class="breadcrumb-item">
+            <a href="{% url 'assignment_detail' assignment_pk %}">
+                {{ assignment.title|truncatewords:5 }}
+            </a>
+        </li>
+        <li class="breadcrumb-item">
+            <a href="{% url 'assignment_question_list' assignment_pk %}">
+                Questions
+            </a>
+        </li>
+        <li class="breadcrumb-item">
+            <a href="{% url 'assignment_question_edit' assignment_pk question.pk %}">
+                {{ object|truncatewords:5 }}
+            </a>
+        </li>
+    </ol>
+</nav>
 {% endblock %}
 
 {% block pagetitle %}
-<div class="float-end">
-    <a class="btn btn-secondary display-inline my-4 me-2"
-       role="button"
-       href="{% url 'assignment_question_edit' assignment_pk question.pk %}"
-       title="Return to question editor">
-        Return to question editor
-    </a>
-    <a class="btn btn-secondary display-inline my-4"
-       role="button"
-       href="{% url 'assignment_question_list' assignment_pk %}"
-       title="Return to question list">
-        Return to question list
-    </a>
-</div>
-
-<h1 class="my-2">{{object.title}}</h1>
+<h1 class="my-2">{{object}}</h1>
 {% endblock %}
 
 {% block js %}
@@ -74,7 +83,7 @@
                         <strong>{{forloop.counter}}. {{mc.text}}</strong>
                         {% for choice in mc.choices %}
                         <div class="form-check mx-4 mb-2">
-                            <input class="form-check-input" type="radio" id="mc_{{mc.pk}}_{{forloop.counter}}" 
+                            <input class="form-check-input" type="radio" id="mc_{{mc.pk}}_{{forloop.counter}}"
                                 name="mc_{{mc.pk}}" value="{{forloop.counter0}}">
                             <label class="form-check-label" for="mc_{{mc.pk}}_{{forloop.counter}}">{{choice}}</label>
                         </div>


### PR DESCRIPTION
The `float: right` on these buttons is messing up the question preview area. I've changed this view to use breadcrumbs like the others, which works better.