### PR TITLE
Fix template error in assignment student view

### DIFF
--- a/econplayground/templates/assignment/assignment_detail_student.html
+++ b/econplayground/templates/assignment/assignment_detail_student.html
@@ -37,15 +37,10 @@
         {% for step in steps %}
             <div class="assignment-step">
                 {{forloop.counter}}.
-                <a href="{% url 'step_detail' object.pk step.0.pk %}">
-                    {% if step.0.name %}
-                        {{ step.0.name }}
-                    {% else %}
-                        Step {{step.0.pk}}
-                    {% endif %}
-                     - {{ step.1 }} attempt{% if step.1 != 1 %}s{% endif %}
+                 <a href="{% url 'step_detail' object.pk step.pk %}">
+                     Step {{step.pk}}
                 </a>
-                {% if step.0.is_last_step %}
+                {% if step.is_last_step %}
                     (End)
                 {% endif %}
             </div>


### PR DESCRIPTION
Undo bug introduced in commit 437333ed1e5bf572236cc4a4db580f2e8f02f6d2:

```
NoReverseMatch at /assignment/3/view/

Reverse for 'step_detail' with arguments '(3, '')' not found. 1 pattern(s) tried: ['assignment/(?P<assignment_pk>[0-9]+)/step/(?P<pk>[0-9]+)/\\Z']
```