### PR TITLE
Fix potential bugs in embed pages

### DIFF
--- a/econplayground/templates/assignment/assignment_embed_public.html
+++ b/econplayground/templates/assignment/assignment_embed_public.html
@@ -50,15 +50,14 @@
         {% for step in steps %}
             <div class="assignment-step">
                 {{forloop.counter}}.
-                <a href="{% url 'step_detail' object.pk step.0.pk %}">
+                <a href="{% url 'step_detail' object.pk step.pk %}">
                     {% if step.0.name %}
                         {{ step.0.name }}
                     {% else %}
                         Step {{step.0.pk}}
                     {% endif %}
-                     - {{ step.1 }} attempt{% if step.1 != 1 %}s{% endif %}
                 </a>
-                {% if step.0.is_last_step %}
+                {% if step.is_last_step %}
                     (End)
                 {% endif %}
             </div>

--- a/econplayground/templates/assignment/assignment_embed_public_minimal.html
+++ b/econplayground/templates/assignment/assignment_embed_public_minimal.html
@@ -40,15 +40,14 @@
                     {% for step in steps %}
                         <div class="assignment-step">
                             {{forloop.counter}}.
-                            <a href="{% url 'step_detail' object.pk step.0.pk %}">
-                                {% if step.0.name %}
-                                    {{ step.0.name }}
+                            <a href="{% url 'step_detail' object.pk step.pk %}">
+                                {% if step.name %}
+                                    {{ step.name }}
                                 {% else %}
-                                    Step {{step.0.pk}}
+                                    Step {{step.pk}}
                                 {% endif %}
-                                - {{ step.1 }} attempt{% if step.1 != 1 %}s{% endif %}
                             </a>
-                            {% if step.0.is_last_step %}
+                            {% if step.is_last_step %}
                                 (End)
                             {% endif %}
                         </div>


### PR DESCRIPTION
This for loop should simply loop through the steps and render the info for each one. Right now it's doing some fancy things with indicies or something which could be problematic.