### PR TITLE
Question + Assignment tables: prevent vertical button stacking

### DIFF
--- a/econplayground/templates/assignment/assignment_list.html
+++ b/econplayground/templates/assignment/assignment_list.html
@@ -60,18 +60,24 @@
                 {% endif %}
             </td>
             <td>
-                <a role="button"
-                   class="btn btn-sm btn-secondary"
-                   title="Edit {{assignment.title}}"
-                   href="{% url 'assignment_assignment_edit' assignment.pk %}">
-                    <i class="bi bi-pencil"></i>
-                </a>
-                <a role="button"
-                   class="btn btn-sm btn-danger"
-                   title="Remove {{assignment.title}}"
-                   href="{% url 'assignment_assignment_delete' assignment.pk %}">
-                    <i class="bi bi-x-lg"></i>
-                </a>
+                <div class="row flex-nowrap g-1">
+                    <div class="col-auto">
+                        <a role="button"
+                           class="btn btn-sm btn-secondary"
+                           title="Edit {{assignment.title}}"
+                           href="{% url 'assignment_assignment_edit' assignment.pk %}">
+                            <i class="bi bi-pencil"></i>
+                        </a>
+                    </div>
+                    <div class="col-auto">
+                        <a role="button"
+                           class="btn btn-sm btn-danger"
+                           title="Remove {{assignment.title}}"
+                           href="{% url 'assignment_assignment_delete' assignment.pk %}">
+                            <i class="bi bi-x-lg"></i>
+                        </a>
+                    </div>
+                </div>
             </td>
         </tr>
         {% empty %}

--- a/econplayground/templates/assignment/assignment_question_list.html
+++ b/econplayground/templates/assignment/assignment_question_list.html
@@ -81,18 +81,24 @@
                             <td>{{question.graph}}</td>
                             <td>{{question.updated_at}}</td>
                             <td>
-                                <a role="button"
-                                   class="btn btn-sm btn-secondary"
-                                   title="Edit {{question}}"
-                                   href="{% url 'assignment_question_edit' assignment.pk question.pk %}">
-                                    <i class="bi bi-pencil"></i>
-                                </a>
-                                <a role="button"
-                                   class="btn btn-sm btn-danger"
-                                   title="Remove {{question}}"
-                                   href="{% url 'assignment_question_delete' assignment.pk question.pk %}">
-                                    <i class="bi bi-x-lg"></i>
-                                </a>
+                                <div class="row flex-nowrap g-1">
+                                    <div class="col-auto">
+                                        <a role="button"
+                                           class="btn btn-sm btn-secondary"
+                                           title="Edit {{question}}"
+                                           href="{% url 'assignment_question_edit' assignment.pk question.pk %}">
+                                            <i class="bi bi-pencil"></i>
+                                        </a>
+                                    </div>
+                                    <div class="col-auto">
+                                        <a role="button"
+                                           class="btn btn-sm btn-danger"
+                                           title="Remove {{question}}"
+                                           href="{% url 'assignment_question_delete' assignment.pk question.pk %}">
+                                            <i class="bi bi-x-lg"></i>
+                                        </a>
+                                    </div>
+                                </div>
                             </td>
                         </tr>
                         {% empty %}


### PR DESCRIPTION
In narrower window widths, these buttons would stack vertically and would be mis-aligned. These changes fix that with `flex-nowrap`.