### PR TITLE
Remove python 3.8 testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-          python-version: ['3.8', '3.12']
+          python-version: ['3.12']
     services:
       postgres:
         image: postgres:15


### PR DESCRIPTION
I will move production over to python 3.12 soon for this application.