### PR TITLE
MinMaxEditor: Fix name attribute

### DIFF
--- a/media/js/src/form-components/MinMaxEditor.jsx
+++ b/media/js/src/form-components/MinMaxEditor.jsx
@@ -17,7 +17,7 @@ export default class MinMaxEditor extends React.Component {
                             this.props.label + ' min' : 'min'}
                     id={this.props.id + 'Min'}
                     data-id={this.props.id + 'Min'}
-                    name={this.props.id}
+                    name={this.props.id + 'Min'}
                     type="number"
                     onChange={this.props.handler}
                     value={this.props.min}
@@ -34,7 +34,7 @@ export default class MinMaxEditor extends React.Component {
                             this.props.label + ' max' : 'max'}
                     id={this.props.id + 'Max'}
                     data-id={this.props.id + 'Max'}
-                    name={this.props.id}
+                    name={this.props.id + 'Max'}
                     type="number"
                     onChange={this.props.handler}
                     value={this.props.max}


### PR DESCRIPTION
This attribute should have min/max appended to it, to avoid conflicting with the main value's name here.