### PR TITLE
Allow sentry-trace and baggage CORS headers

### DIFF
--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -2,6 +2,7 @@
 import sys
 import os
 import os.path
+from corsheaders.defaults import default_headers
 from ctlsettings.shared import common
 
 project = 'econplayground'
@@ -45,6 +46,7 @@ REST_FRAMEWORK = {
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
@@ -86,6 +88,7 @@ INSTALLED_APPS = [  # noqa
     's3sign',
     'treebeard',
     'markdownify.apps.MarkdownifyConfig',
+    'corsheaders',
 ]
 
 CONTACT_US_EMAIL = 'econpractice@columbia.edu'
@@ -174,3 +177,9 @@ MARKDOWNIFY = {
         ]
     }
 }
+
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+    'sentry-trace',
+    'baggage',
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ typing_extensions==4.12.2
 pyparsing==3.1.4
 
 django-s3sign==0.4.0
-
+django-cors-headers==4.4.0
 django-treebeard==4.7.1
 
 graphviz==0.20.3


### PR DESCRIPTION
https://docs.sentry.io/platforms/javascript/guides/react/tracing/trace-propagation/dealing-with-cors-issues/

On production, a few sentry resources are blocked:
```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://js.sentry-cdn.com/228b00835993445782defce7ab192600.min.js. (Reason: CORS request did not succeed). Status code: (null).
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://js.sentry-cdn.com/228b00835993445782defce7ab192600.min.js. (Reason: CORS request did not succeed). Status code: (null).
```

These changes may fix that by allowing them via CORS headers.