### PR TITLE
Update pip dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
+  allow:
+    - dependency-name: "ctlsettings"
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
What I'm trying to do is allow dependabot to include minor version updates for the ctlsettings package, because I would like these PRs to happen automatically.

I'm not sure if this change will actually do that, but I figured I would try.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow