### PR TITLE
Remove unnecessary dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
-  allow:
-    - dependency-name: "ctlsettings"
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
These lines are unnecessary, because all patch-level updates are already happening on this project. Some of our other projects have this config in dependabot.yml, which prevents minor version updates from coming through:
```
  ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-patch"]
```