### PR TITLE
Don't fail when viewing a graph without a topic

### DIFF
--- a/econplayground/main/mixins.py
+++ b/econplayground/main/mixins.py
@@ -29,10 +29,14 @@ class CohortGraphMixin(object):
     """
     def dispatch(self, *args, **kwargs):
         if not hasattr(self, 'cohort'):
+            self.cohort = None
+
             graph_pk = kwargs.get('pk', None)
             if graph_pk:
                 graph = get_object_or_404(Graph, pk=graph_pk)
-                self.cohort = graph.topic.cohort
+
+                if graph and graph.topic and graph.topic.cohort:
+                    self.cohort = graph.topic.cohort
 
         return super(CohortGraphMixin, self).dispatch(
             self.request, *args, **kwargs)


### PR DESCRIPTION
When loading old graphs, it's possible to fail due to a missing topic. This doesn't need to happen, and I think it's okay to allow orphaned graphs to load.

Addresses sentry error ECONPLAYGROUND-7T