### PR TITLE
LTI config: add contextmembership.readonly scope

### DIFF
--- a/econplayground/lti/views.py
+++ b/econplayground/lti/views.py
@@ -42,7 +42,12 @@ class JSONConfigView(View):
             'target_link_uri': target_link_uri,
             'scopes': [
                 'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
-                'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly'
+
+                'https://purl.imsglobal.org/'
+                'spec/lti-ags/scope/result.readonly',
+
+                'https://purl.imsglobal.org/'
+                'spec/lti-nrps/scope/contextmembership.readonly',
             ],
             'extensions': [
                 {


### PR DESCRIPTION
This should allow access to course and user data through LTI: https://canvas.instructure.com/doc/api/names_and_role.html