### PR TITLE
AssessmentRule.__str__: fix error when user_friendly_name is not defined

### DIFF
--- a/econplayground/main/models.py
+++ b/econplayground/main/models.py
@@ -568,7 +568,9 @@ class AssessmentRule(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
+        user_friendly_name = self.name
         assessment_type = self.name[5:]
+
         if self.name[4] == '1':
             if assessment_type == 'intercept':
                 user_friendly_name = 'Orange-Blue Intersection'
@@ -584,6 +586,7 @@ class AssessmentRule(models.Model):
                 user_friendly_name = 'Orange-Red Intersection'
             else:
                 user_friendly_name = 'Red Line ' + assessment_type
+
         return 'AssessmentRule: {}, {}'.format(user_friendly_name, self.value)
 
     class Meta:


### PR DESCRIPTION
user_friendly_name is not defined when the rule is not line-based, such as `x_axis_label`, causing an exception. This change fixes that.

Sentry error ECONPLAYGROUND-8Q