### PR TITLE
Add new Graph Help view

### DIFF
--- a/econplayground/main/models.py
+++ b/econplayground/main/models.py
@@ -404,7 +404,13 @@ class Graph(OrderedModel):
         g.save()
         return g
 
-    def get_assessment_rules(self):
+    @staticmethod
+    def get_rule_options(graph_type: int = 0) -> object:
+        """
+        This is a back-end version of Graph.getRuleOptions() on the
+        front-end. Most of the logic is built out there at the moment,
+        but I expect to consolidate these two pieces of logic.
+        """
         line_actions = [
             'up',
             'down',
@@ -434,7 +440,7 @@ class Graph(OrderedModel):
         }
 
         # TODO: extend possible rules for the various other graph types
-        if self.graph_type == 8:
+        if graph_type == 8:
             rules.update({
                 'line3': {
                     'name': 'Green line',

--- a/econplayground/main/views.py
+++ b/econplayground/main/views.py
@@ -16,6 +16,7 @@ from django.views.generic.edit import (
     CreateView, FormView, UpdateView, DeleteView
 )
 from django.views.generic.detail import SingleObjectMixin
+from django.views.generic.base import TemplateView
 from lti_provider.mixins import LTIAuthMixin
 from lti_provider.views import LTILandingPage
 from s3sign.views import SignS3View
@@ -30,7 +31,7 @@ from econplayground.main.mixins import (
 from econplayground.main.models import (
     Cohort, Graph, Submission, Topic
 )
-from econplayground.main.utils import user_is_instructor
+from econplayground.main.utils import user_is_instructor, get_graph_name
 
 
 class EnsureCsrfCookieMixin(object):
@@ -325,6 +326,22 @@ class GraphDetailView(CohortGraphMixin, CohortPasswordMixin, DetailView):
         url = '{}?return_type=iframe&width={}&height={}&url={}'.format(
             return_url, 640, 600, iframe_url)
         return HttpResponseRedirect(url)
+
+
+class GraphHelpView(TemplateView):
+    template_name = 'main/graph_help.html'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+
+        graph_type = kwargs.get('graph_type')
+        graph_name = get_graph_name(graph_type)
+        ctx.update({
+            'rule_options': Graph.get_rule_options(graph_type),
+            'graph_name': graph_name,
+        })
+
+        return ctx
 
 
 class GraphEmbedView(CsrfExemptMixin, LTIAuthMixin, DetailView):

--- a/econplayground/templates/main/graph_help.html
+++ b/econplayground/templates/main/graph_help.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% block title %}Graph help: {{ graph_name }}{% endblock %}
+
+{% block content %}
+<div>
+    <h4 class="mt-2">
+        Rule options for graph type: <strong>{{ graph_name }}</strong>
+    </h4>
+
+<pre>
+{{ rule_options | pprint }}
+</pre>
+
+</div>
+{% endblock %}

--- a/econplayground/urls.py
+++ b/econplayground/urls.py
@@ -85,6 +85,8 @@ urlpatterns = [
 
     path('graph/<int:pk>/',
          views.GraphDetailView.as_view(), name='graph_detail'),
+    path('graph/<int:graph_type>/help/',
+         views.GraphHelpView.as_view(), name='graph_help'),
     path('graph/<int:pk>/embed/',
          views.GraphEmbedView.as_view(), name='graph_embed'),
     path('graph/<int:pk>/public/',


### PR DESCRIPTION
This view prints all assessment options based on graph type. This is a rough implementation so far - this will be cleaned up and expanded, and then linked to from the graph editor.