### PR TITLE
Simplify Graph.get_rule_options() and add tests

### DIFF
--- a/econplayground/main/models.py
+++ b/econplayground/main/models.py
@@ -377,14 +377,10 @@ class Graph(OrderedModel):
         """
         module = importlib.import_module('econplayground.main.graphs')
 
-        # Find dynamic graph class name using its graph type.
-        graph_class = getattr(module, 'Graph{}'.format(graph_type))
-        if graph_class:
-            instance = graph_class()
-            return instance.get_rule_options()
-
-        # Fall back to the generic BaseGraph's implementation.
-        return BaseGraph.get_rule_options()
+        # Find dynamic graph class name using its graph type. Fall
+        # back to the generic BaseGraph's implementation.
+        graph_class = getattr(module, 'Graph{}'.format(graph_type), BaseGraph)
+        return graph_class.get_rule_options()
 
 
 class JXGLine(models.Model):

--- a/econplayground/main/tests/test_models.py
+++ b/econplayground/main/tests/test_models.py
@@ -84,6 +84,24 @@ class GraphTest(TestCase):
         rule_options = self.x.get_rule_options()
         self.assertTrue(isinstance(rule_options, dict))
 
+        # Valid graphs
+        rule_options = self.x.get_rule_options(1)
+        self.assertTrue(isinstance(rule_options, dict))
+
+        rule_options = self.x.get_rule_options(3)
+        self.assertTrue(isinstance(rule_options, dict))
+
+        # Invalid
+        rule_options = self.x.get_rule_options(-1)
+        self.assertTrue(
+            isinstance(rule_options, dict),
+            'Doesn\'t fail on invalid graph type.')
+
+        rule_options = self.x.get_rule_options(99)
+        self.assertTrue(
+            isinstance(rule_options, dict),
+            'Doesn\'t fail on invalid graph type.')
+
 
 class JXGLineTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Using the `default` parameter of `getattr()`, we can remove some unnecessary logic here.

Additionally, `get_rule_options()` is a class method on the graph classes, so the class doesn't actually need to be instantiated in order to call it.