### PR TITLE
Allow graph background to be undefined

### DIFF
--- a/media/css/econplayground.css
+++ b/media/css/econplayground.css
@@ -17,10 +17,6 @@
     margin-left: 10px;
 }
 
-figure#editing-graph {
-    background-color: white;
-}
-
 .ep-text-red {
     color: red;
 }

--- a/media/js/src/JXGBoard.jsx
+++ b/media/js/src/JXGBoard.jsx
@@ -638,7 +638,6 @@ export default class JXGBoard extends React.Component {
                 showNavigation: false,
                 boundingBox: boundingBox
             });
-        this.board.renderer.svgRoot.style.backgroundColor = 'white';
         this.board1InitObjects = this.board.numObjects;
 
         window.board = this.board;
@@ -700,7 +699,6 @@ export default class JXGBoard extends React.Component {
                 showNavigation: false,
                 boundingBox: boundingBox
             });
-        this.board2.renderer.svgRoot.style.backgroundColor = 'white';
 
         this.board2InitObjects = this.board2.numObjects;
 


### PR DESCRIPTION
I think it's better to not explicitly set this to `white`.