### PR TITLE
LTI config: Allow configurable LTI platform

### DIFF
--- a/econplayground/lti/views.py
+++ b/econplayground/lti/views.py
@@ -35,6 +35,10 @@ class JSONConfigView(View):
             'https://{}'.format(domain),
             reverse('oidc_init', kwargs={'registration_uuid': uuid}))
 
+        lti_platform = 'columbiasce.test.instructure.com'
+        if hasattr(settings, 'LTI_PLATFORM'):
+            lti_platform = settings.LTI_PLATFORM
+
         json_obj = {
             'title': title,
             'description': settings.LTI_TOOL_CONFIGURATION['description'],
@@ -53,7 +57,7 @@ class JSONConfigView(View):
                 {
                     'domain': domain,
                     'tool_id': 'econpractice',
-                    'platform': 'columbiasce.test.instructure.com',
+                    'platform': lti_platform,
                     'privacy_level': 'public',
                     'settings': {
                         'text': 'Launch ' + title,


### PR DESCRIPTION
We can control this in django settings to point to courseworks-prod on production.