### PR TITLE
Fix default alpha value for Cobb-Douglas graph.

### DIFF
--- a/media/js/src/graphUtils.js
+++ b/media/js/src/graphUtils.js
@@ -102,7 +102,7 @@ export const setDynamicGraphDefaults = function(state, updateObj) {
 export const getDefaultGraphState = function(graphType, state) {
     // Specific defaults based on graph type.
 
-    if (graphType == 3) {
+    if (graphType === 3) {
         Object.assign(state, cobbDouglasDefaults);
     } else if (graphType === 15) {
         state.gA4 = 0.5;

--- a/media/js/src/graphs/CobbDouglasGraph.js
+++ b/media/js/src/graphs/CobbDouglasGraph.js
@@ -3,6 +3,7 @@ import {Graph, getIntersectionPointOptions, positiveRange} from './Graph.js';
 export const defaults = {
     gA1Name: 'A',
     gA2Name: 'L',
+    gA4: 0.6,
     gA3Name: 'K',
     gA5Name: 'Y'
 };


### PR DESCRIPTION
This needs to be between 0 and 1, not 2 as is set in Editor.js.