### PR TITLE
Implement LTI 1.3 Dynamic Registration

### DIFF
--- a/econplayground/lti/urls.py
+++ b/econplayground/lti/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
 from econplayground.lti.views import (
-    JSONConfigView, LtiLaunchView, MyOIDCLoginInitView
+    JSONConfigView, LtiLaunchView, MyOIDCLoginInitView,
+    DynamicRegistrationView
 )
 from lti_tool.views import jwks
 
@@ -14,4 +15,5 @@ urlpatterns = [
     path('<uuid:registration_uuid>/config.json',
          JSONConfigView.as_view()),
     path('launch/', LtiLaunchView.as_view(), name='lti-launch'),
+    path('tool_configuration', DynamicRegistrationView.as_view()),
 ]

--- a/econplayground/lti/views.py
+++ b/econplayground/lti/views.py
@@ -1,14 +1,42 @@
-from django.conf import settings
-from django.http import JsonResponse
+from django.conf import settings, LazySettings
+from django.http import JsonResponse, HttpResponse
+from django.shortcuts import render
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic.base import View, TemplateView
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from lti_tool.views import LtiLaunchBaseView, OIDCLoginInitView
+from lti_dynamic_registration.views import DynamicRegistrationBaseView
+from lti_dynamic_registration.types import (
+    CanvasLtiToolConfiguration, CanvasLtiRegistration, CanvasLtiMessage
+)
+from lti_dynamic_registration.constants import CanvasPrivacyLevel
 
 from econplayground.main.models import Cohort
+
+
+def ensure_https(url: str) -> str:
+    if not url.startswith('http://') and not url.startswith('https://'):
+        return 'https://' + url
+    return url
+
+
+def is_static_file_remote(path: str) -> bool:
+    url = static(path)
+    parsed = urlparse(url)
+    return bool(parsed.scheme and parsed.netloc)
+
+
+def get_icon_url(settings: LazySettings, host: str) -> str:
+    icon_url = static(settings.LTI_TOOL_CONFIGURATION['embed_icon_url'])
+
+    if not is_static_file_remote(icon_url):
+        icon_url = urljoin(f'https://{host}', icon_url)
+
+    return icon_url
 
 
 class JSONConfigView(View):
@@ -24,16 +52,14 @@ class JSONConfigView(View):
     def get(self, request, *args, **kwargs):
         domain = request.get_host()
         title = settings.LTI_TOOL_CONFIGURATION['title']
-        icon_url = urljoin(
-            settings.STATIC_URL,
-            settings.LTI_TOOL_CONFIGURATION['embed_icon_url'])
+        icon_url = static(settings.LTI_TOOL_CONFIGURATION['embed_icon_url'])
         target_link_uri = urljoin(
             'https://{}'.format(domain), reverse('lti-launch'))
 
-        uuid = kwargs.get('registration_uuid')
+        uuid_str = kwargs.get('registration_uuid')
         oidc_init_uri = urljoin(
             'https://{}'.format(domain),
-            reverse('oidc_init', kwargs={'registration_uuid': uuid}))
+            reverse('oidc_init', kwargs={'registration_uuid': uuid_str}))
 
         lti_platform = 'columbiasce.test.instructure.com'
         if hasattr(settings, 'LTI_PLATFORM'):
@@ -145,3 +171,106 @@ class LtiLaunchView(LtiLaunchBaseView, TemplateView):
             'course_id': self.course_id,
             'course_name': self.course_name,
         }
+
+
+class DynamicRegistrationView(DynamicRegistrationBaseView):
+    tool_friendly_name = 'EconPractice'
+    lti_platform = 'columbiasce.test.instructure.com'
+
+    def dispatch(self, *args, **kwargs) -> HttpResponse:
+        if hasattr(settings, 'LTI_PLATFORM'):
+            self.lti_platform = settings.LTI_PLATFORM
+
+        return super().dispatch(*args, **kwargs)
+
+    def get(self, request, *args, **kwargs) -> HttpResponse:
+        context = {
+            # Pass in a default lti_platform
+            'lti_platform': ensure_https(self.lti_platform),
+        }
+        return render(request, 'lti/registration.html', context)
+
+    def post(self, request, *args, **kwargs) -> HttpResponse:
+        # Perform the registration steps. Typically this would involve:
+        # 1. Register the platform in the tool
+        issuer = request.POST.get('issuer')
+        if issuer:
+            issuer = issuer.strip()
+            issuer = ensure_https(issuer)
+
+        authorization_endpoint = urljoin(issuer, '/api/lti/authorize_redirect')
+
+        token_endpoint = urljoin(issuer, '/login/oauth2/token')
+        jwks_uri = urljoin(issuer, '/api/lti/security/jwks')
+
+        reg = self.register_platform_in_tool(
+            issuer, {
+                'issuer': issuer,
+                'authorization_endpoint': authorization_endpoint,
+                'token_endpoint': token_endpoint,
+                'jwks_uri': jwks_uri,
+            }
+        )
+
+        # 2. Register the tool in the platform
+        openid_config = self.get_openid_config()
+        privacy_level = CanvasPrivacyLevel('public')
+        host = request.get_host()
+        target_link_uri = f'https://{host}/lti/launch/'
+        icon_url = get_icon_url(settings, host)
+        oidc_init_uri = urljoin(
+            'https://{}'.format(host),
+            reverse('oidc_init', kwargs={'registration_uuid': reg.uuid}))
+
+        lti_tool_config = CanvasLtiToolConfiguration(
+            domain=self.lti_platform,
+            target_link_uri=target_link_uri,
+            claims=[
+                'sub',
+                'iss',
+                'name',
+                'given_name',
+                'family_name',
+                'nickname',
+                'picture',
+                'email',
+                'locale'
+            ],
+            messages=[
+                CanvasLtiMessage(
+                    label='EconPractice',
+                    icon_uri=icon_url,
+                    type='LtiResourceLinkRequest',
+                    placements=['course_navigation'],
+                    target_link_uri=target_link_uri,
+                    default_enabled=True
+                )
+            ],
+            description=settings.LTI_TOOL_CONFIGURATION['description'],
+            privacy_level=privacy_level,
+            tool_id='econpractice',
+        )
+        tool_platform_registration = CanvasLtiRegistration(
+            client_name='EconPractice',
+            target_link_uri=target_link_uri,
+            initiate_login_uri=oidc_init_uri,
+            jwks_uri=jwks_uri,
+            scopes=[
+                'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
+            ],
+            lti_tool_configuration=lti_tool_config,
+        )
+
+        if settings.DEBUG:
+            print('registration', tool_platform_registration.to_dict())
+        client_id = self.register_tool_in_platform(
+            openid_config, tool_platform_registration)
+
+        # 3. Update the platform registration with the client ID
+        # returned in step 2
+        reg.client_id = client_id
+        reg.save()
+
+        # Return a page containing javascript that calls a special
+        # platform postMessage endpoint
+        return self.success_response()

--- a/econplayground/settings_shared.py
+++ b/econplayground/settings_shared.py
@@ -96,6 +96,7 @@ INSTALLED_APPS = [  # noqa
     'corsheaders',
 
     'lti_tool',
+    'lti_dynamic_registration',
 
     'ctlsettings',
 ]

--- a/econplayground/templates/lti/registration.html
+++ b/econplayground/templates/lti/registration.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>EconPractice: LTI 1.3 Dynamic Registration</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous">
+    </head>
+    <body class="container">
+
+        <h5>
+            EconPractice: LTI 1.3 Dynamic Registration
+        </h5>
+
+        <form method="post">
+            {% csrf_token %}
+            <div class="mb-3">
+                <label for="issuerInput" class="form-label">Issuer</label>
+                <input type="text" class="form-control" name="issuer" required
+                       id="issuerInput" aria-describedby="issuerHelp"
+                       value="{{ lti_platform }}">
+                <div id="issuerHelp" class="form-text">e.g.: https://courseworks2.columbia.edu/</div>
+            </div>
+            <button type="submit" class="btn btn-primary">Submit</button>
+        </form>
+
+    </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,6 +93,7 @@ pyjwt==2.10.1  # pylti1p3
 jwcrypto==1.5.6  # pylti1p3
 PyLTI1p3==2.0.0  # django-lti
 django-lti==0.8.0
+django-lti-dynamic-registration==0.1.1
 django-lti-authentication==0.2.0
 
 django-braces==1.17.0


### PR DESCRIPTION
This allows for a newer form of LTI app registration within Canvas.

* https://community.canvaslms.com/t5/The-Product-Blog/Installing-LTI-1-3-Tools-is-Easier-than-Ever-with-Dynamic/ba-p/597089
* https://www.imsglobal.org/spec/lti-dr/v1p0
* Using this library: https://github.com/Harvard-University-iCommons/django-lti-dynamic-registration

<img width="1010" height="678" alt="Screenshot_2025-07-25_12-02-12" src="https://github.com/user-attachments/assets/38613412-c580-48e4-ba50-7a87266f158c" />
