### PR TITLE
Fix missing assessment rules on graph type 13

### DIFF
--- a/econplayground/main/graphs.py
+++ b/econplayground/main/graphs.py
@@ -360,6 +360,7 @@ class Graph13(BaseGraph):
             'x-axis-2 label': 'X-axis label',
             'y-axis-2 label': 'Y-axis label',
         })
+        return rules
 
 
 class Graph14(BaseGraph):


### PR DESCRIPTION
Another place where I missed a `return` statement here.