### PR TITLE
Remove user-friendly AssessmentRule name

### DIFF
--- a/econplayground/main/models.py
+++ b/econplayground/main/models.py
@@ -484,35 +484,6 @@ class AssessmentRule(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
-    def __str__(self):
-        user_friendly_name = self.name
-
-        assessment_type = ''
-        if len(self.name) > 5:
-            assessment_type = ' ' + self.name[5:]
-
-        line_number = None
-        if len(self.name) > 3 and self.name[:4] == 'line':
-            line_number = int(self.name[4])
-
-        if line_number == 1:
-            if assessment_type.strip() == 'intercept':
-                user_friendly_name = 'Orange-Blue intersection'
-            else:
-                user_friendly_name = 'Orange line' + assessment_type
-        elif line_number == 2:
-            if assessment_type.strip() == 'intercept':
-                user_friendly_name = 'Blue-Red intersection'
-            else:
-                user_friendly_name = 'Blue line' + assessment_type
-        elif line_number == 3:
-            if assessment_type.strip() == 'intercept':
-                user_friendly_name = 'Orange-Red intersection'
-            else:
-                user_friendly_name = 'Red line' + assessment_type
-
-        return 'AssessmentRule: {} - {}'.format(user_friendly_name, self.value)
-
     class Meta:
         ordering = ('name',)
         unique_together = ('assessment', 'name', 'value',)

--- a/econplayground/main/tests/test_models.py
+++ b/econplayground/main/tests/test_models.py
@@ -131,25 +131,6 @@ class AssessmentRuleTest(TestCase):
     def test_is_valid_from_factory(self):
         self.x.full_clean()
 
-    def test_str(self):
-        rule1 = AssessmentRuleFactory(name='')
-        rule2 = AssessmentRuleFactory(name='line2')
-        rule3 = AssessmentRuleFactory(name='a')
-        rule4 = AssessmentRuleFactory(name='x_axis_label')
-
-        self.assertEqual(
-            str(rule1),
-            'AssessmentRule: {} - {}'.format(rule1.name, rule1.value))
-        self.assertEqual(
-            str(rule2),
-            'AssessmentRule: Blue line - {}'.format(rule2.value))
-        self.assertEqual(
-            str(rule3),
-            'AssessmentRule: {} - {}'.format(rule3.name, rule3.value))
-        self.assertEqual(
-            str(rule4),
-            'AssessmentRule: {} - {}'.format(rule4.name, rule4.value))
-
     def test_multiple_rules(self):
         AssessmentRuleFactory(assessment=self.x.assessment)
         AssessmentRuleFactory(assessment=self.x.assessment)


### PR DESCRIPTION
This code is prone to break based on the assessment rule names - I don't think we need this for now, since we have the assessment rule map documented. Resolves sentry error ECONPLAYGROUND-9X